### PR TITLE
geom_alt props

### DIFF
--- a/data/421/195/703/421195703.geojson
+++ b/data/421/195/703/421195703.geojson
@@ -599,6 +599,9 @@
     },
     "wof:country":"TN",
     "wof:created":1459009856,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"68aa7a430472e0a72c7edfcb570ec90c",
     "wof:hierarchy":[
         {
@@ -610,7 +613,7 @@
         }
     ],
     "wof:id":421195703,
-    "wof:lastmodified":1566667303,
+    "wof:lastmodified":1582318849,
     "wof:name":"Tunis",
     "wof:parent_id":85679123,
     "wof:placetype":"locality",

--- a/data/856/327/03/85632703.geojson
+++ b/data/856/327/03/85632703.geojson
@@ -930,8 +930,7 @@
     "src:geom_alt":[
         "naturalearth",
         "quattroshapes",
-        "meso",
-        "naturalearth"
+        "meso"
     ],
     "src:geom_via":"meso",
     "src:lbl_centroid":"mapshaper",
@@ -1009,7 +1008,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1582318845,
+    "wof:lastmodified":1583205683,
     "wof:name":"Tunisia",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/327/03/85632703.geojson
+++ b/data/856/327/03/85632703.geojson
@@ -928,6 +928,7 @@
     "qs:source":"US State Department, with Natural Earth mods",
     "src:geom":"whosonfirst",
     "src:geom_alt":[
+        "naturalearth",
         "quattroshapes",
         "meso",
         "naturalearth"
@@ -986,6 +987,12 @@
     },
     "wof:country":"TN",
     "wof:country_alpha3":"TUN",
+    "wof:geom_alt":[
+        "naturalearth-display-terrestrial-zoom6",
+        "quattroshapes",
+        "meso",
+        "naturalearth"
+    ],
     "wof:geomhash":"1a9b84dc62a9eb4fc2de6bd3d78e0443",
     "wof:hierarchy":[
         {
@@ -1002,7 +1009,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1566667165,
+    "wof:lastmodified":1582318845,
     "wof:name":"Tunisia",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/790/95/85679095.geojson
+++ b/data/856/790/95/85679095.geojson
@@ -272,6 +272,9 @@
         "wk:page":"Tozeur Governorate"
     },
     "wof:country":"TN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ab6d8e6036cf79f1d6c3ccc60731d0a2",
     "wof:hierarchy":[
         {
@@ -289,7 +292,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1566667160,
+    "wof:lastmodified":1582318842,
     "wof:name":"Tozeur",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/790/99/85679099.geojson
+++ b/data/856/790/99/85679099.geojson
@@ -313,6 +313,9 @@
         "wd:id":"Q734328"
     },
     "wof:country":"TN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2a72438f51d52bcce1bc353fd38cf810",
     "wof:hierarchy":[
         {
@@ -330,7 +333,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1566667160,
+    "wof:lastmodified":1582318842,
     "wof:name":"Manubah",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/791/03/85679103.geojson
+++ b/data/856/791/03/85679103.geojson
@@ -255,6 +255,9 @@
         "wk:page":"B\u00e9ja Governorate"
     },
     "wof:country":"TN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9bd3dd6bb3cc9842d2c54469e6c7d7c3",
     "wof:hierarchy":[
         {
@@ -272,7 +275,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1566667160,
+    "wof:lastmodified":1582318843,
     "wof:name":"B\u00e9ja",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/791/07/85679107.geojson
+++ b/data/856/791/07/85679107.geojson
@@ -290,6 +290,9 @@
         "wk:page":"Ben Arous Governorate"
     },
     "wof:country":"TN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4bee5ff292c443be543c699f84ebbe8c",
     "wof:hierarchy":[
         {
@@ -307,7 +310,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1566667162,
+    "wof:lastmodified":1582318844,
     "wof:name":"Ben Arous (Tunis Sud)",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/791/13/85679113.geojson
+++ b/data/856/791/13/85679113.geojson
@@ -281,6 +281,9 @@
         "wk:page":"Bizerte Governorate"
     },
     "wof:country":"TN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7cbded015a7e53ff7eb570d6c3f52fdd",
     "wof:hierarchy":[
         {
@@ -298,7 +301,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1566667164,
+    "wof:lastmodified":1582318845,
     "wof:name":"Bizerte",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/791/15/85679115.geojson
+++ b/data/856/791/15/85679115.geojson
@@ -275,6 +275,9 @@
         "wk:page":"Jendouba Governorate"
     },
     "wof:country":"TN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0c8952425587bbc555cbb2b74f266c90",
     "wof:hierarchy":[
         {
@@ -292,7 +295,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1566667164,
+    "wof:lastmodified":1582318845,
     "wof:name":"Jendouba",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/791/19/85679119.geojson
+++ b/data/856/791/19/85679119.geojson
@@ -278,6 +278,9 @@
         "wk:page":"Nabeul Governorate"
     },
     "wof:country":"TN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bb19d6fd527fcd44e40754cdc5ff0322",
     "wof:hierarchy":[
         {
@@ -295,7 +298,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1566667162,
+    "wof:lastmodified":1582318844,
     "wof:name":"Nabeul",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/791/23/85679123.geojson
+++ b/data/856/791/23/85679123.geojson
@@ -240,6 +240,9 @@
         "wk:page":"Tunis Governorate"
     },
     "wof:country":"TN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"493eab8f1dbd24955b8fe182d3655a60",
     "wof:hierarchy":[
         {
@@ -257,7 +260,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1566667164,
+    "wof:lastmodified":1582318845,
     "wof:name":"Tunis",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/791/31/85679131.geojson
+++ b/data/856/791/31/85679131.geojson
@@ -281,6 +281,9 @@
         "wd:id":"Q328199"
     },
     "wof:country":"TN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"64c145fa0b08a44699f2104b6933fdd8",
     "wof:hierarchy":[
         {
@@ -298,7 +301,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1566667162,
+    "wof:lastmodified":1582318844,
     "wof:name":"Le Kef",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/791/33/85679133.geojson
+++ b/data/856/791/33/85679133.geojson
@@ -276,6 +276,9 @@
         "wk:page":"Kasserine Governorate"
     },
     "wof:country":"TN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"29cdf977066fb8fee7b2dc23217b51a1",
     "wof:hierarchy":[
         {
@@ -293,7 +296,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1566667161,
+    "wof:lastmodified":1582318843,
     "wof:name":"Kass\u00e9rine",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/791/37/85679137.geojson
+++ b/data/856/791/37/85679137.geojson
@@ -285,6 +285,9 @@
         "wk:page":"Gab\u00e8s Governorate"
     },
     "wof:country":"TN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2232de832bd7f8246243214b117d406b",
     "wof:hierarchy":[
         {
@@ -302,7 +305,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1566667163,
+    "wof:lastmodified":1582318844,
     "wof:name":"Gab\u00e8s",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/791/41/85679141.geojson
+++ b/data/856/791/41/85679141.geojson
@@ -284,6 +284,9 @@
         "wd:id":"Q269968"
     },
     "wof:country":"TN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ca562187e8a0476cad7fc76f562bc980",
     "wof:hierarchy":[
         {
@@ -301,7 +304,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1566667163,
+    "wof:lastmodified":1582318844,
     "wof:name":"Gafsa",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/791/47/85679147.geojson
+++ b/data/856/791/47/85679147.geojson
@@ -274,6 +274,9 @@
         "wk:page":"Sidi Bouzid Governorate"
     },
     "wof:country":"TN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"406065cd721d16f5db97b36cbdec29f5",
     "wof:hierarchy":[
         {
@@ -291,7 +294,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1566667164,
+    "wof:lastmodified":1582318845,
     "wof:name":"Sidi Bou Zid",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/791/51/85679151.geojson
+++ b/data/856/791/51/85679151.geojson
@@ -281,6 +281,9 @@
         "wk:page":"Sfax Governorate"
     },
     "wof:country":"TN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f4f2b77cd5c01930958470c61dfb94f8",
     "wof:hierarchy":[
         {
@@ -298,7 +301,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1566667161,
+    "wof:lastmodified":1582318843,
     "wof:name":"Sfax",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/791/57/85679157.geojson
+++ b/data/856/791/57/85679157.geojson
@@ -272,6 +272,9 @@
         "wk:page":"Siliana Governorate"
     },
     "wof:country":"TN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"29851d6e2f4294fdee61d458cbcba0f2",
     "wof:hierarchy":[
         {
@@ -289,7 +292,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1566667160,
+    "wof:lastmodified":1582318843,
     "wof:name":"Siliana",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/791/61/85679161.geojson
+++ b/data/856/791/61/85679161.geojson
@@ -275,6 +275,9 @@
         "wk:page":"Mahdia Governorate"
     },
     "wof:country":"TN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bbda24930264846b90d01c98628ff082",
     "wof:hierarchy":[
         {
@@ -292,7 +295,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1566667160,
+    "wof:lastmodified":1582318843,
     "wof:name":"Mahdia",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/791/65/85679165.geojson
+++ b/data/856/791/65/85679165.geojson
@@ -284,6 +284,9 @@
         "wk:page":"Monastir Governorate"
     },
     "wof:country":"TN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"654699bb6293de09a135057f68e29566",
     "wof:hierarchy":[
         {
@@ -301,7 +304,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1566667162,
+    "wof:lastmodified":1582318844,
     "wof:name":"Monastir",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/791/71/85679171.geojson
+++ b/data/856/791/71/85679171.geojson
@@ -236,6 +236,9 @@
         "wk:page":"Kairouan Governorate"
     },
     "wof:country":"TN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"378026095600aa932acd0f609c1083e6",
     "wof:hierarchy":[
         {
@@ -253,7 +256,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1566667164,
+    "wof:lastmodified":1582318845,
     "wof:name":"Kairouan",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/791/73/85679173.geojson
+++ b/data/856/791/73/85679173.geojson
@@ -278,6 +278,9 @@
         "wk:page":"Sousse Governorate"
     },
     "wof:country":"TN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"33979d2b2ed7388d18129f6d637cc3c1",
     "wof:hierarchy":[
         {
@@ -295,7 +298,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1566667161,
+    "wof:lastmodified":1582318843,
     "wof:name":"Sousse",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/791/79/85679179.geojson
+++ b/data/856/791/79/85679179.geojson
@@ -272,6 +272,9 @@
         "wk:page":"Zaghouan Governorate"
     },
     "wof:country":"TN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0402401fa81c48f2ca18ffffb3da5da0",
     "wof:hierarchy":[
         {
@@ -289,7 +292,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1566667163,
+    "wof:lastmodified":1582318844,
     "wof:name":"Zaghouan",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/791/83/85679183.geojson
+++ b/data/856/791/83/85679183.geojson
@@ -276,6 +276,9 @@
         "wk:page":"Medenine Governorate"
     },
     "wof:country":"TN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7641dd6060a3faccacf761a2601543c8",
     "wof:hierarchy":[
         {
@@ -293,7 +296,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1566667163,
+    "wof:lastmodified":1582318844,
     "wof:name":"M\u00e9denine",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/791/87/85679187.geojson
+++ b/data/856/791/87/85679187.geojson
@@ -279,6 +279,9 @@
         "wk:page":"Kebili Governorate"
     },
     "wof:country":"TN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f89014265508eca36226f32152c9e75e",
     "wof:hierarchy":[
         {
@@ -296,7 +299,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1566667161,
+    "wof:lastmodified":1582318843,
     "wof:name":"Kebili",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/791/91/85679191.geojson
+++ b/data/856/791/91/85679191.geojson
@@ -278,6 +278,9 @@
         "wk:page":"Tataouine Governorate"
     },
     "wof:country":"TN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4a4f18c0ca09d0d68d271c5e09884ce4",
     "wof:hierarchy":[
         {
@@ -295,7 +298,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1566667162,
+    "wof:lastmodified":1582318844,
     "wof:name":"Tataouine",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/859/029/07/85902907.geojson
+++ b/data/859/029/07/85902907.geojson
@@ -79,6 +79,10 @@
         "qs_pg:id":316879
     },
     "wof:country":"TN",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"46ddd5bdeb4ca965068d39fb1cf4e294",
     "wof:hierarchy":[
         {
@@ -94,7 +98,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566667159,
+    "wof:lastmodified":1582318842,
     "wof:name":"Al \u2018Umr\u0101n",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/029/09/85902909.geojson
+++ b/data/859/029/09/85902909.geojson
@@ -79,6 +79,10 @@
         "qs_pg:id":229259
     },
     "wof:country":"TN",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"ddcb2b7d3970493f89cf45d0d665d012",
     "wof:hierarchy":[
         {
@@ -94,7 +98,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566667159,
+    "wof:lastmodified":1582318842,
     "wof:name":"B\u00e5b as Suwayqah",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/029/11/85902911.geojson
+++ b/data/859/029/11/85902911.geojson
@@ -72,6 +72,10 @@
         "qs_pg:id":1168076
     },
     "wof:country":"TN",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"7b9b1f5424be4b81d2409b30d1c8a186",
     "wof:hierarchy":[
         {
@@ -87,7 +91,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566667159,
+    "wof:lastmodified":1582318842,
     "wof:name":"Beau Site",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/029/13/85902913.geojson
+++ b/data/859/029/13/85902913.geojson
@@ -176,6 +176,10 @@
         "qs_pg:id":448298
     },
     "wof:country":"TN",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1814977c4adab6e90524cf89c932f8be",
     "wof:hierarchy":[
         {
@@ -191,7 +195,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566667160,
+    "wof:lastmodified":1582318842,
     "wof:name":"Belv\u00e9d\u00e8re",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/029/15/85902915.geojson
+++ b/data/859/029/15/85902915.geojson
@@ -87,6 +87,10 @@
         "qs_pg:id":1116983
     },
     "wof:country":"TN",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"db488fc07412ce34dfbc74b3a0f43176",
     "wof:hierarchy":[
         {
@@ -102,7 +106,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566667159,
+    "wof:lastmodified":1582318842,
     "wof:name":"La M\u00e9dina",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/029/17/85902917.geojson
+++ b/data/859/029/17/85902917.geojson
@@ -414,6 +414,10 @@
         "qs_pg:id":1064582
     },
     "wof:country":"TN",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e442027d6e6915550a5fc9ed14352639",
     "wof:hierarchy":[
         {
@@ -429,7 +433,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566667159,
+    "wof:lastmodified":1582318842,
     "wof:name":"Medina",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/073/39/85907339.geojson
+++ b/data/859/073/39/85907339.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":230488
     },
     "wof:country":"TN",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0717bc8c8a01f6f3971cfa66ca681021",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566667158,
+    "wof:lastmodified":1582318842,
     "wof:name":"Cite Rommana",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/073/41/85907341.geojson
+++ b/data/859/073/41/85907341.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":1262817
     },
     "wof:country":"TN",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bf0879203cc70a8edff39b9aa8d4ee64",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566667159,
+    "wof:lastmodified":1582318842,
     "wof:name":"Cite El Habib",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/073/43/85907343.geojson
+++ b/data/859/073/43/85907343.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":237514
     },
     "wof:country":"TN",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c80bc1c06247bf3839c7a77b85ab7f7e",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566667158,
+    "wof:lastmodified":1582318842,
     "wof:name":"Bou Choucha",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/073/45/85907345.geojson
+++ b/data/859/073/45/85907345.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":230430
     },
     "wof:country":"TN",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"c3d25f9edf845e40154b42a929c4e02c",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566667158,
+    "wof:lastmodified":1582318842,
     "wof:name":"El Halfaouine",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/073/47/85907347.geojson
+++ b/data/859/073/47/85907347.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":1257488
     },
     "wof:country":"TN",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"290efd231ea3d0b5ccfef69e1e4ea3ba",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566667159,
+    "wof:lastmodified":1582318842,
     "wof:name":"Cite Jardins",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/073/51/85907351.geojson
+++ b/data/859/073/51/85907351.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":237578
     },
     "wof:country":"TN",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7a74096e45b6093d7700eaedc17b7e40",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566667158,
+    "wof:lastmodified":1582318842,
     "wof:name":"Cite Olympique",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/073/53/85907353.geojson
+++ b/data/859/073/53/85907353.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":366851
     },
     "wof:country":"TN",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"c9a2ee504ede08eb60fd91eaf0fa832e",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566667158,
+    "wof:lastmodified":1582318842,
     "wof:name":"Cite Somrane",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/073/55/85907355.geojson
+++ b/data/859/073/55/85907355.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":990017
     },
     "wof:country":"TN",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"09668627f5d5199d9a9d219621c7fd7c",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566667158,
+    "wof:lastmodified":1582318842,
     "wof:name":"Sayda El Manoubia",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/073/57/85907357.geojson
+++ b/data/859/073/57/85907357.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":1242053
     },
     "wof:country":"TN",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"98951db1e5e9eee3fa5e06fbd57fe71d",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566667157,
+    "wof:lastmodified":1582318842,
     "wof:name":"Tourbet El Bey",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/073/59/85907359.geojson
+++ b/data/859/073/59/85907359.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":1087586
     },
     "wof:country":"TN",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9c9117ec72ef73516135aca8d2c1f859",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566667157,
+    "wof:lastmodified":1582318842,
     "wof:name":"La Kasba",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/073/61/85907361.geojson
+++ b/data/859/073/61/85907361.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":1087587
     },
     "wof:country":"TN",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"a33755d9622baa2651b194f51beb34ee",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566667157,
+    "wof:lastmodified":1582318841,
     "wof:name":"Bab Bhar",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/073/63/85907363.geojson
+++ b/data/859/073/63/85907363.geojson
@@ -105,6 +105,10 @@
         "qs_pg:id":1087588
     },
     "wof:country":"TN",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"48704ad80a4383b3ae6c9d9887e9fc78",
     "wof:hierarchy":[
         {
@@ -120,7 +124,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566667158,
+    "wof:lastmodified":1582318842,
     "wof:name":"Le Passage",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/073/65/85907365.geojson
+++ b/data/859/073/65/85907365.geojson
@@ -73,6 +73,10 @@
         "qs_pg:id":14543
     },
     "wof:country":"TN",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3a468894f47c57c7be0e8ea697e70027",
     "wof:hierarchy":[
         {
@@ -88,7 +92,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566667158,
+    "wof:lastmodified":1582318842,
     "wof:name":"Port de Tunis",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/073/69/85907369.geojson
+++ b/data/859/073/69/85907369.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":14544
     },
     "wof:country":"TN",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"b55d011a1e3093144e5fc363a6210a30",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566667157,
+    "wof:lastmodified":1582318842,
     "wof:name":"Jbal Lahmar",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.