### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/102/542/887/102542887.geojson
+++ b/data/102/542/887/102542887.geojson
@@ -31,11 +31,20 @@
     "name:fas_x_preferred":[
         "\u0641\u0631\u0648\u062f\u06af\u0627\u0647 \u0628\u0648\u0631\u06cc \u0627\u0644 \u0627\u0645\u0631\u0627\u06cc"
     ],
+    "name:fas_x_variant":[
+        "\u0641\u0631\u0648\u062f\u06af\u0627\u0647 \u0628\u0631\u062c\u200c\u0627\u0644\u0639\u0627\u0645\u0631\u06cc"
+    ],
     "name:msa_x_preferred":[
         "Lapangan Terbang Borj El Amri"
     ],
     "name:tgk_x_preferred":[
         "\u0424\u0443\u0440\u0443\u0434\u0433\u043e\u04b3\u0438 \u0431\u0443\u0440\u0438 \u0438\u043b \u0443\u043c\u0430\u0440\u043e"
+    ],
+    "name:tur_x_preferred":[
+        "Burc\u00fc'l-Amri Havaliman\u0131"
+    ],
+    "name:vie_x_preferred":[
+        "S\u00e2n bay Borj El Amri"
     ],
     "oa:elevation_ft":"110",
     "oa:type":"small_airport",
@@ -68,7 +77,7 @@
         }
     ],
     "wof:id":102542887,
-    "wof:lastmodified":1631745260,
+    "wof:lastmodified":1690874830,
     "wof:name":"Bordj El Amri Airport",
     "wof:parent_id":85679099,
     "wof:placetype":"campus",

--- a/data/110/880/715/9/1108807159.geojson
+++ b/data/110/880/715/9/1108807159.geojson
@@ -47,6 +47,9 @@
     "name:cat_x_variant":[
         "governaci\u00f3 d'Ariana"
     ],
+    "name:che_x_preferred":[
+        "\u0410\u0440\u044c\u044f\u043d\u0430"
+    ],
     "name:cym_x_preferred":[
         "Ariana"
     ],
@@ -60,7 +63,8 @@
         "Ariana"
     ],
     "name:eng_x_variant":[
-        "Ariana Governorate"
+        "Ariana Governorate",
+        "Tunis Governorate"
     ],
     "name:fas_x_preferred":[
         "\u0627\u0633\u062a\u0627\u0646 \u0627\u0631\u06cc\u0627\u0646\u0647"
@@ -76,6 +80,12 @@
     ],
     "name:frr_x_preferred":[
         "Ariana"
+    ],
+    "name:gle_x_preferred":[
+        "Ariana"
+    ],
+    "name:heb_x_preferred":[
+        "\u05d0\u05e8\u05d9\u05d0\u05e0\u05d4"
     ],
     "name:hun_x_preferred":[
         "Ariana korm\u00e1nyz\u00f3s\u00e1g"
@@ -94,6 +104,9 @@
     ],
     "name:kor_x_preferred":[
         "\uc544\ub9ac\uc544\ub098 \uc8fc"
+    ],
+    "name:kor_x_variant":[
+        "\uc544\ub9ac\uc544\ub098\uc8fc"
     ],
     "name:lit_x_preferred":[
         "Arianos vilajetas"
@@ -131,6 +144,9 @@
     "name:swe_x_preferred":[
         "Ariana"
     ],
+    "name:tha_x_preferred":[
+        "\u0e40\u0e02\u0e15\u0e1c\u0e39\u0e49\u0e27\u0e48\u0e32\u0e01\u0e32\u0e23\u0e2d\u0e31\u0e23\u0e22\u0e32\u0e19\u0e30\u0e2e\u0e4c"
+    ],
     "name:tur_x_preferred":[
         "Aryana Vilayeti"
     ],
@@ -145,6 +161,9 @@
     ],
     "name:zho_x_preferred":[
         "\u827e\u723e\u4e9e\u5167\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Ariana Governorate"
     ],
     "src:geom":"meso",
     "src:lbl_centroid":"mapshaper",
@@ -192,7 +211,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1614896198,
+    "wof:lastmodified":1690874839,
     "wof:name":"Ariana",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/112/577/629/9/1125776299.geojson
+++ b/data/112/577/629/9/1125776299.geojson
@@ -25,11 +25,17 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0645\u0639\u0645\u0648\u0631\u0629"
     ],
+    "name:cat_x_preferred":[
+        "El M\u00e2amoura"
+    ],
     "name:ceb_x_preferred":[
         "El Maamoura"
     ],
     "name:eng_x_preferred":[
         "El Ma\u00e2moura"
+    ],
+    "name:fas_x_preferred":[
+        "\u0627\u0644\u0645\u0639\u0645\u0648\u0631\u0647"
     ],
     "name:fra_x_preferred":[
         "El Ma\u00e2moura"
@@ -37,11 +43,17 @@
     "name:nld_x_preferred":[
         "El Ma\u00e2moura"
     ],
+    "name:tur_x_preferred":[
+        "El-Mamure"
+    ],
     "name:ukr_x_preferred":[
         "\u0415\u043b\u044c-\u041c\u0430\u0430\u043c\u0443\u0440\u0430"
     ],
     "name:und_x_variant":[
         "Al Ma\u2018m\u016brah"
+    ],
+    "name:zul_x_preferred":[
+        "El Ma\u00e2moura"
     ],
     "qs_pg:aaroncc":"TN",
     "qs_pg:gn_country":"TN",
@@ -82,7 +94,7 @@
         }
     ],
     "wof:id":1125776299,
-    "wof:lastmodified":1566667329,
+    "wof:lastmodified":1690874871,
     "wof:name":"El Maamoura",
     "wof:parent_id":1108757563,
     "wof:placetype":"locality",

--- a/data/112/579/252/1/1125792521.geojson
+++ b/data/112/579/252/1/1125792521.geojson
@@ -34,14 +34,26 @@
     "name:ceb_x_preferred":[
         "Nibbar"
     ],
+    "name:deu_x_preferred":[
+        "Nebeur"
+    ],
     "name:eng_x_preferred":[
         "Nebeur"
+    ],
+    "name:fas_x_preferred":[
+        "\u0646\u0628\u0631"
     ],
     "name:fra_x_preferred":[
         "Nebeur"
     ],
+    "name:tur_x_preferred":[
+        "Nebra"
+    ],
     "name:ukr_x_preferred":[
         "\u041d\u0430\u0431\u0435\u0440"
+    ],
+    "name:zul_x_preferred":[
+        "Nebeur"
     ],
     "qs_pg:aaroncc":"TN",
     "qs_pg:gn_country":"TN",
@@ -82,7 +94,7 @@
         }
     ],
     "wof:id":1125792521,
-    "wof:lastmodified":1566667329,
+    "wof:lastmodified":1690874871,
     "wof:name":"Nibbar",
     "wof:parent_id":1108757461,
     "wof:placetype":"locality",

--- a/data/112/586/061/3/1125860613.geojson
+++ b/data/112/586/061/3/1125860613.geojson
@@ -25,11 +25,20 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0645\u0627\u062a\u0644\u064a\u0646"
     ],
+    "name:cat_x_preferred":[
+        "Metline"
+    ],
     "name:ceb_x_preferred":[
         "Al Matl\u012bn"
     ],
+    "name:deu_x_preferred":[
+        "Metline"
+    ],
     "name:eng_x_preferred":[
         "Metline"
+    ],
+    "name:fas_x_preferred":[
+        "\u0627\u0644\u0645\u0627\u062a\u0644\u06cc\u0646"
     ],
     "name:fra_x_preferred":[
         "Metline"
@@ -42,6 +51,9 @@
     ],
     "name:und_x_variant":[
         "El Metline"
+    ],
+    "name:zul_x_preferred":[
+        "Metline"
     ],
     "qs_pg:aaroncc":"TN",
     "qs_pg:gn_country":"TN",
@@ -82,7 +94,7 @@
         }
     ],
     "wof:id":1125860613,
-    "wof:lastmodified":1566667327,
+    "wof:lastmodified":1690874868,
     "wof:name":"Al Matl\u012bn",
     "wof:parent_id":1108757301,
     "wof:placetype":"locality",

--- a/data/112/586/945/1/1125869451.geojson
+++ b/data/112/586/945/1/1125869451.geojson
@@ -31,8 +31,14 @@
     "name:ceb_x_preferred":[
         "Maj\u0101z al B\u0101b"
     ],
+    "name:ces_x_preferred":[
+        "Mad\u017eaz al Bab"
+    ],
     "name:eng_x_preferred":[
         "Majaz al Bab"
+    ],
+    "name:fas_x_preferred":[
+        "\u0645\u062c\u0627\u0632 \u0627\u0644\u0628\u0627\u0628"
     ],
     "name:fra_x_preferred":[
         "Medjez el-Bab"
@@ -46,14 +52,26 @@
     "name:nld_x_preferred":[
         "Medjez el-Bab"
     ],
+    "name:tur_x_preferred":[
+        "Mecaz\u00fc'l-Bab"
+    ],
     "name:ukr_x_preferred":[
         "\u041c\u0435\u0434\u0436\u0430\u0437-\u0435\u043b\u044c-\u0411\u0430\u0431"
     ],
     "name:und_x_variant":[
         "Medjez el Bab"
     ],
+    "name:urd_x_preferred":[
+        "\u0645\u062c\u0627\u0632 \u0627\u0644\u0628\u0627\u0628"
+    ],
     "name:zho_x_preferred":[
         "\u9ea5\u5fb7\u5091\u65af\u5967\u5df4\u5e03"
+    ],
+    "name:zho_x_variant":[
+        "\u8fc8\u8d3e\u5179\u5df4\u535c"
+    ],
+    "name:zul_x_preferred":[
+        "Majaz al Bab"
     ],
     "qs_pg:aaroncc":"TN",
     "qs_pg:gn_country":"TN",
@@ -94,7 +112,7 @@
         }
     ],
     "wof:id":1125869451,
-    "wof:lastmodified":1566667327,
+    "wof:lastmodified":1690874869,
     "wof:name":"Maj\u0101z al B\u0101b",
     "wof:parent_id":1108757261,
     "wof:placetype":"locality",

--- a/data/112/588/169/7/1125881697.geojson
+++ b/data/112/588/169/7/1125881697.geojson
@@ -37,6 +37,9 @@
     "name:eng_x_preferred":[
         "Sejenane"
     ],
+    "name:fas_x_preferred":[
+        "\u0633\u062c\u0646\u0627\u0646"
+    ],
     "name:fra_x_preferred":[
         "Sejnane"
     ],
@@ -57,6 +60,12 @@
     ],
     "name:ukr_x_preferred":[
         "\u0421\u0435\u0436\u0435\u043d\u0430\u043d"
+    ],
+    "name:zho_x_preferred":[
+        "\u585e\u52a0\u5c3c"
+    ],
+    "name:zul_x_preferred":[
+        "Sejnane"
     ],
     "qs_pg:aaroncc":"TN",
     "qs_pg:gn_country":"TN",
@@ -97,7 +106,7 @@
         }
     ],
     "wof:id":1125881697,
-    "wof:lastmodified":1566667328,
+    "wof:lastmodified":1690874869,
     "wof:name":"Sejenane",
     "wof:parent_id":1108757303,
     "wof:placetype":"locality",

--- a/data/112/588/170/5/1125881705.geojson
+++ b/data/112/588/170/5/1125881705.geojson
@@ -25,6 +25,9 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u062d\u0627\u0645\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u062d\u0627\u0645\u0647"
+    ],
     "name:cat_x_preferred":[
         "El Hamma"
     ],
@@ -37,13 +40,25 @@
     "name:deu_x_preferred":[
         "El Hamma"
     ],
+    "name:ell_x_preferred":[
+        "\u0395\u03bb \u03a7\u03b1\u03bc\u03ac"
+    ],
     "name:eng_x_preferred":[
         "El Hamma"
+    ],
+    "name:fas_x_preferred":[
+        "\u0627\u0644\u062d\u0627\u0645\u0647"
     ],
     "name:fra_x_preferred":[
         "El Hamma"
     ],
+    "name:heb_x_preferred":[
+        "\u05d0\u05dc \u05d7\u05de\u05d0"
+    ],
     "name:hun_x_preferred":[
+        "El Hamma"
+    ],
+    "name:ita_x_preferred":[
         "El Hamma"
     ],
     "name:kor_x_preferred":[
@@ -58,6 +73,12 @@
     "name:rus_x_preferred":[
         "\u042d\u043b\u044c-\u0425\u0430\u043c\u043c\u0430"
     ],
+    "name:swe_x_preferred":[
+        "El Hamma"
+    ],
+    "name:tur_x_preferred":[
+        "El-Hamma"
+    ],
     "name:ukr_x_preferred":[
         "\u0415\u043b\u044c-\u0425\u0430\u043c\u0430"
     ],
@@ -69,6 +90,9 @@
     ],
     "name:zho_x_preferred":[
         "\u54c8\u9081"
+    ],
+    "name:zul_x_preferred":[
+        "El Hamma"
     ],
     "qs_pg:aaroncc":"TN",
     "qs_pg:gn_country":"TN",
@@ -109,7 +133,7 @@
         }
     ],
     "wof:id":1125881705,
-    "wof:lastmodified":1566667328,
+    "wof:lastmodified":1690874869,
     "wof:name":"El Hamma",
     "wof:parent_id":1108757307,
     "wof:placetype":"locality",

--- a/data/112/589/694/7/1125896947.geojson
+++ b/data/112/589/694/7/1125896947.geojson
@@ -40,7 +40,13 @@
     "name:eng_x_preferred":[
         "El Haouaria"
     ],
+    "name:fas_x_preferred":[
+        "\u0627\u0644\u0647\u0648\u0627\u0631\u06cc\u0647"
+    ],
     "name:fra_x_preferred":[
+        "El Haouaria"
+    ],
+    "name:ita_x_preferred":[
         "El Haouaria"
     ],
     "name:nld_x_preferred":[
@@ -52,11 +58,17 @@
     "name:swe_x_preferred":[
         "El Haouaria"
     ],
+    "name:tur_x_preferred":[
+        "El-Huvariye"
+    ],
     "name:ukr_x_preferred":[
         "\u0415\u043b\u044c-\u0425\u0443\u0430\u0440\u0456\u044f"
     ],
     "name:und_x_variant":[
         "Al H\u016bw\u0101r\u012byah"
+    ],
+    "name:zul_x_preferred":[
+        "El Haouaria"
     ],
     "qs_pg:aaroncc":"TN",
     "qs_pg:gn_country":"TN",
@@ -97,7 +109,7 @@
         }
     ],
     "wof:id":1125896947,
-    "wof:lastmodified":1566667328,
+    "wof:lastmodified":1690874869,
     "wof:name":"El Haouaria",
     "wof:parent_id":1108757577,
     "wof:placetype":"locality",

--- a/data/112/591/475/7/1125914757.geojson
+++ b/data/112/591/475/7/1125914757.geojson
@@ -34,6 +34,9 @@
     "name:eng_x_preferred":[
         "Takelsa"
     ],
+    "name:fas_x_preferred":[
+        "\u062a\u0627\u06a9\u0644\u0633\u0647"
+    ],
     "name:fra_x_preferred":[
         "Takelsa"
     ],
@@ -43,8 +46,14 @@
     "name:nld_x_preferred":[
         "Takelsa"
     ],
+    "name:tur_x_preferred":[
+        "Teklise"
+    ],
     "name:ukr_x_preferred":[
         "\u0422\u0430\u043a\u0435\u043b\u0441\u0430"
+    ],
+    "name:zul_x_preferred":[
+        "Takelsa"
     ],
     "qs_pg:aaroncc":"TN",
     "qs_pg:gn_country":"TN",
@@ -85,7 +94,7 @@
         }
     ],
     "wof:id":1125914757,
-    "wof:lastmodified":1566667328,
+    "wof:lastmodified":1690874870,
     "wof:name":"T\u0101klisah",
     "wof:parent_id":1108757593,
     "wof:placetype":"locality",

--- a/data/112/591/476/5/1125914765.geojson
+++ b/data/112/591/476/5/1125914765.geojson
@@ -34,8 +34,14 @@
     "name:cym_x_preferred":[
         "Tajerouine"
     ],
+    "name:deu_x_preferred":[
+        "Tajerouine"
+    ],
     "name:eng_x_preferred":[
         "Tajerouine"
+    ],
+    "name:fas_x_preferred":[
+        "\u062a\u0627\u062c\u0631\u0648\u06cc\u0646"
     ],
     "name:fra_x_preferred":[
         "Tajerouine"
@@ -43,11 +49,17 @@
     "name:nld_x_preferred":[
         "Tajerouine"
     ],
+    "name:tur_x_preferred":[
+        "Tecruvin"
+    ],
     "name:ukr_x_preferred":[
         "\u0422\u0430\u0436\u0435\u0440\u0432\u0456\u043d"
     ],
     "name:und_x_variant":[
         "Tadjrou\u00efne"
+    ],
+    "name:zul_x_preferred":[
+        "Tajerouine"
     ],
     "qs_pg:aaroncc":"TN",
     "qs_pg:gn_country":"TN",
@@ -88,7 +100,7 @@
         }
     ],
     "wof:id":1125914765,
-    "wof:lastmodified":1566667328,
+    "wof:lastmodified":1690874869,
     "wof:name":"Tajerouine",
     "wof:parent_id":1108757465,
     "wof:placetype":"locality",

--- a/data/112/591/477/9/1125914779.geojson
+++ b/data/112/591/477/9/1125914779.geojson
@@ -34,6 +34,9 @@
     "name:cat_x_preferred":[
         "Jendouba"
     ],
+    "name:ceb_x_preferred":[
+        "Jendouba"
+    ],
     "name:cym_x_preferred":[
         "Jendouba"
     ],
@@ -88,6 +91,9 @@
     "name:pol_x_preferred":[
         "Jendouba"
     ],
+    "name:pol_x_variant":[
+        "D\u017cunduba"
+    ],
     "name:por_x_preferred":[
         "Jendouba"
     ],
@@ -106,6 +112,9 @@
     "name:swe_x_preferred":[
         "Jendouba"
     ],
+    "name:tha_x_preferred":[
+        "\u0e0d\u0e31\u0e19\u0e14\u0e39\u0e1a\u0e30\u0e2e\u0e4c"
+    ],
     "name:tur_x_preferred":[
         "Cendube"
     ],
@@ -123,6 +132,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5805\u675c\u62dc"
+    ],
+    "name:zul_x_preferred":[
+        "Jendouba"
     ],
     "qs_pg:aaroncc":"TN",
     "qs_pg:gn_country":"TN",
@@ -163,7 +175,7 @@
         }
     ],
     "wof:id":1125914779,
-    "wof:lastmodified":1636495673,
+    "wof:lastmodified":1690874870,
     "wof:name":"Jendouba",
     "wof:parent_id":1108757365,
     "wof:placetype":"locality",

--- a/data/112/591/480/1/1125914801.geojson
+++ b/data/112/591/480/1/1125914801.geojson
@@ -28,11 +28,17 @@
     "name:cat_x_preferred":[
         "Gremda"
     ],
+    "name:ceb_x_preferred":[
+        "Al Qarmadah"
+    ],
     "name:deu_x_preferred":[
         "Gremda"
     ],
     "name:eng_x_preferred":[
         "Gremda"
+    ],
+    "name:fas_x_preferred":[
+        "\u0642\u0631\u0645\u062f\u0647"
     ],
     "name:fra_x_preferred":[
         "Gremda"
@@ -43,8 +49,17 @@
     "name:sco_x_preferred":[
         "Gremda"
     ],
+    "name:tur_x_preferred":[
+        "Karmada"
+    ],
     "name:ukr_x_preferred":[
         "\u041a\u0440\u0435\u043c\u0434\u0430"
+    ],
+    "name:urd_x_preferred":[
+        "\u0642\u0631\u0645\u062f\u06c1"
+    ],
+    "name:zul_x_preferred":[
+        "Gremda"
     ],
     "qs_pg:aaroncc":"TN",
     "qs_pg:gn_country":"TN",
@@ -85,7 +100,7 @@
         }
     ],
     "wof:id":1125914801,
-    "wof:lastmodified":1566667328,
+    "wof:lastmodified":1690874870,
     "wof:name":"Al Qarmadah",
     "wof:parent_id":1108757621,
     "wof:placetype":"locality",

--- a/data/112/591/481/1/1125914811.geojson
+++ b/data/112/591/481/1/1125914811.geojson
@@ -34,17 +34,26 @@
     "name:eng_x_preferred":[
         "El Mida"
     ],
+    "name:fas_x_preferred":[
+        "\u0627\u0644\u0645\u06cc\u062f\u0647"
+    ],
     "name:fra_x_preferred":[
         "El Mida"
     ],
     "name:nld_x_preferred":[
         "El Mida"
     ],
+    "name:tur_x_preferred":[
+        "El-Mida"
+    ],
     "name:ukr_x_preferred":[
         "\u0415\u043b\u044c-\u041c\u0456\u0434\u0430"
     ],
     "name:und_x_variant":[
         "Mida"
+    ],
+    "name:zul_x_preferred":[
+        "El Mida"
     ],
     "qs_pg:aaroncc":"TN",
     "qs_pg:gn_country":"TN",
@@ -85,7 +94,7 @@
         }
     ],
     "wof:id":1125914811,
-    "wof:lastmodified":1566667328,
+    "wof:lastmodified":1690874870,
     "wof:name":"El Mida",
     "wof:parent_id":1108757571,
     "wof:placetype":"locality",

--- a/data/112/598/827/7/1125988277.geojson
+++ b/data/112/598/827/7/1125988277.geojson
@@ -37,6 +37,9 @@
     "name:eng_x_preferred":[
         "Korba"
     ],
+    "name:fas_x_preferred":[
+        "\u0642\u0631\u0628\u0647"
+    ],
     "name:fra_x_preferred":[
         "Korba"
     ],
@@ -61,6 +64,12 @@
     "name:sco_x_preferred":[
         "Korba"
     ],
+    "name:spa_x_preferred":[
+        "Korba"
+    ],
+    "name:tur_x_preferred":[
+        "Kurbe"
+    ],
     "name:ukr_x_preferred":[
         "\u041a\u043e\u0440\u0431\u0430"
     ],
@@ -69,6 +78,9 @@
     ],
     "name:zho_x_preferred":[
         "\u67ef\u5df4"
+    ],
+    "name:zul_x_preferred":[
+        "Korba"
     ],
     "qs_pg:aaroncc":"TN",
     "qs_pg:gn_country":"TN",
@@ -109,7 +121,7 @@
         }
     ],
     "wof:id":1125988277,
-    "wof:lastmodified":1566667329,
+    "wof:lastmodified":1690874870,
     "wof:name":"Korba",
     "wof:parent_id":1108757581,
     "wof:placetype":"locality",

--- a/data/112/598/829/3/1125988293.geojson
+++ b/data/112/598/829/3/1125988293.geojson
@@ -37,6 +37,9 @@
     "name:eng_x_preferred":[
         "El Alia"
     ],
+    "name:fas_x_preferred":[
+        "\u0627\u0644\u0639\u0627\u0644\u06cc\u0647"
+    ],
     "name:fra_x_preferred":[
         "El Alia"
     ],
@@ -51,6 +54,9 @@
     ],
     "name:und_x_variant":[
         "Uzalis"
+    ],
+    "name:zul_x_preferred":[
+        "El Alia"
     ],
     "qs_pg:aaroncc":"TN",
     "qs_pg:gn_country":"TN",
@@ -91,7 +97,7 @@
         }
     ],
     "wof:id":1125988293,
-    "wof:lastmodified":1566667329,
+    "wof:lastmodified":1690874871,
     "wof:name":"Al \u2018\u0100liyah",
     "wof:parent_id":1108757283,
     "wof:placetype":"locality",

--- a/data/114/190/598/9/1141905989.geojson
+++ b/data/114/190/598/9/1141905989.geojson
@@ -18,14 +18,29 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":12.0,
+    "name:afr_x_preferred":[
+        "Medenine"
+    ],
     "name:ara_x_preferred":[
         "\u0645\u062f\u0646\u064a\u0646"
+    ],
+    "name:arg_x_preferred":[
+        "Medenine"
+    ],
+    "name:ast_x_preferred":[
+        "Medenine"
     ],
     "name:azb_x_preferred":[
         "\u0645\u062f\u0646\u06cc\u0646"
     ],
+    "name:bar_x_preferred":[
+        "Medenine"
+    ],
     "name:ben_x_preferred":[
         "\u09ae\u09c7\u09a6\u09c7\u09a8\u09be\u0987\u09a8"
+    ],
+    "name:bre_x_preferred":[
+        "Medenine"
     ],
     "name:bul_x_preferred":[
         "\u041c\u0435\u0434\u0435\u043d\u0438\u043d\u0435"
@@ -34,6 +49,12 @@
         "M\u00e9denine"
     ],
     "name:ceb_x_preferred":[
+        "Medenine"
+    ],
+    "name:ces_x_preferred":[
+        "Madan\u00edn"
+    ],
+    "name:cos_x_preferred":[
         "Medenine"
     ],
     "name:cym_x_preferred":[
@@ -54,6 +75,15 @@
     "name:eng_x_preferred":[
         "Medenine"
     ],
+    "name:epo_x_preferred":[
+        "Medenine"
+    ],
+    "name:est_x_preferred":[
+        "Medenine"
+    ],
+    "name:eus_x_preferred":[
+        "Medenine"
+    ],
     "name:fas_x_preferred":[
         "\u0645\u062f\u0646\u06cc\u0646"
     ],
@@ -63,13 +93,52 @@
     "name:fra_x_preferred":[
         "M\u00e9denine"
     ],
+    "name:frp_x_preferred":[
+        "Medenine"
+    ],
+    "name:fur_x_preferred":[
+        "Medenine"
+    ],
+    "name:gla_x_preferred":[
+        "Medenine"
+    ],
+    "name:gle_x_preferred":[
+        "Medenine"
+    ],
+    "name:glg_x_preferred":[
+        "Medenine"
+    ],
+    "name:gsw_x_preferred":[
+        "Medenine"
+    ],
+    "name:heb_x_preferred":[
+        "\u05de\u05d3\u05e0\u05d9\u05df"
+    ],
     "name:hin_x_preferred":[
         "\u092e\u0947\u0921\u0947\u0928\u093e\u0907\u0928"
+    ],
+    "name:hrv_x_preferred":[
+        "Medenine"
     ],
     "name:hun_x_preferred":[
         "M\u00e9denine"
     ],
+    "name:hun_x_variant":[
+        "Meden\u00edn"
+    ],
+    "name:ido_x_preferred":[
+        "Medenine"
+    ],
+    "name:ile_x_preferred":[
+        "Medenine"
+    ],
+    "name:ina_x_preferred":[
+        "Medenine"
+    ],
     "name:ind_x_preferred":[
+        "Medenine"
+    ],
+    "name:isl_x_preferred":[
         "Medenine"
     ],
     "name:ita_x_preferred":[
@@ -81,14 +150,59 @@
     "name:kab_x_preferred":[
         "Mednin"
     ],
+    "name:kon_x_preferred":[
+        "Medenine"
+    ],
     "name:kor_x_preferred":[
         "\uba54\ub4dc\ub2cc"
+    ],
+    "name:lij_x_preferred":[
+        "Medenine"
+    ],
+    "name:lim_x_preferred":[
+        "Medenine"
     ],
     "name:lit_x_preferred":[
         "Medeninas"
     ],
+    "name:ltz_x_preferred":[
+        "Medenine"
+    ],
+    "name:min_x_preferred":[
+        "Medenine"
+    ],
+    "name:mlg_x_preferred":[
+        "Medenine"
+    ],
+    "name:msa_x_preferred":[
+        "Medenine"
+    ],
+    "name:nap_x_preferred":[
+        "Medenine"
+    ],
+    "name:nds_x_preferred":[
+        "Medenine"
+    ],
     "name:nld_x_preferred":[
         "M\u00e9denine"
+    ],
+    "name:nno_x_preferred":[
+        "Medenine"
+    ],
+    "name:nob_x_preferred":[
+        "Medenine"
+    ],
+    "name:nrm_x_preferred":[
+        "Medenine"
+    ],
+    "name:oci_x_preferred":[
+        "Medenine"
+    ],
+    "name:pcd_x_preferred":[
+        "Medenine"
+    ],
+    "name:pms_x_preferred":[
+        "Medenine"
     ],
     "name:pol_x_preferred":[
         "Madanin"
@@ -96,20 +210,41 @@
     "name:por_x_preferred":[
         "M\u00e9denine"
     ],
+    "name:roh_x_preferred":[
+        "Medenine"
+    ],
     "name:ron_x_preferred":[
         "Medenine"
     ],
     "name:rus_x_preferred":[
         "\u041c\u0435\u0434\u0435\u043d\u0438\u043d"
     ],
+    "name:scn_x_preferred":[
+        "Medenine"
+    ],
     "name:sco_x_preferred":[
+        "Medenine"
+    ],
+    "name:slk_x_preferred":[
+        "Medenine"
+    ],
+    "name:slv_x_preferred":[
         "Medenine"
     ],
     "name:spa_x_preferred":[
         "M\u00e9denine"
     ],
+    "name:srd_x_preferred":[
+        "Medenine"
+    ],
+    "name:swa_x_preferred":[
+        "Medenine"
+    ],
     "name:swe_x_preferred":[
         "Medenine"
+    ],
+    "name:tha_x_preferred":[
+        "\u0e21\u0e30\u0e14\u0e30\u0e19\u0e35\u0e19"
     ],
     "name:tur_x_preferred":[
         "Medenin"
@@ -120,11 +255,29 @@
     "name:urd_x_preferred":[
         "\u0645\u062f\u0646\u06cc\u0646"
     ],
+    "name:vec_x_preferred":[
+        "Medenine"
+    ],
     "name:vie_x_preferred":[
+        "Medenine"
+    ],
+    "name:vls_x_preferred":[
+        "Medenine"
+    ],
+    "name:vol_x_preferred":[
+        "Medenine"
+    ],
+    "name:wln_x_preferred":[
+        "Medenine"
+    ],
+    "name:wol_x_preferred":[
         "Medenine"
     ],
     "name:zho_x_preferred":[
         "\u6885\u5fb7\u5be7"
+    ],
+    "name:zul_x_preferred":[
+        "Medenine"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Tunisia",
@@ -245,7 +398,7 @@
         }
     ],
     "wof:id":1141905989,
-    "wof:lastmodified":1636495674,
+    "wof:lastmodified":1690874873,
     "wof:name":"Medenine",
     "wof:parent_id":1108757523,
     "wof:placetype":"locality",

--- a/data/114/190/599/3/1141905993.geojson
+++ b/data/114/190/599/3/1141905993.geojson
@@ -30,6 +30,9 @@
     "name:cat_x_preferred":[
         "Jendouba"
     ],
+    "name:ceb_x_preferred":[
+        "Jendouba"
+    ],
     "name:cym_x_preferred":[
         "Jendouba"
     ],
@@ -84,6 +87,9 @@
     "name:pol_x_preferred":[
         "Jendouba"
     ],
+    "name:pol_x_variant":[
+        "D\u017cunduba"
+    ],
     "name:por_x_preferred":[
         "Jendouba"
     ],
@@ -102,6 +108,9 @@
     "name:swe_x_preferred":[
         "Jendouba"
     ],
+    "name:tha_x_preferred":[
+        "\u0e0d\u0e31\u0e19\u0e14\u0e39\u0e1a\u0e30\u0e2e\u0e4c"
+    ],
     "name:tur_x_preferred":[
         "Cendube"
     ],
@@ -116,6 +125,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5805\u675c\u62dc"
+    ],
+    "name:zul_x_preferred":[
+        "Jendouba"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Tunisia",
@@ -236,7 +248,7 @@
         }
     ],
     "wof:id":1141905993,
-    "wof:lastmodified":1636495673,
+    "wof:lastmodified":1690874872,
     "wof:name":"Jendouba",
     "wof:parent_id":1108757369,
     "wof:placetype":"locality",

--- a/data/114/190/599/5/1141905995.geojson
+++ b/data/114/190/599/5/1141905995.geojson
@@ -69,6 +69,9 @@
     "name:hun_x_preferred":[
         "Kasszerine"
     ],
+    "name:hye_x_preferred":[
+        "\u053f\u0561\u057d\u0565\u0580\u056b\u0576"
+    ],
     "name:ind_x_preferred":[
         "Kasserine"
     ],
@@ -114,6 +117,9 @@
     "name:swe_x_preferred":[
         "Kasserine"
     ],
+    "name:tha_x_preferred":[
+        "\u0e2d\u0e31\u0e25\u0e01\u0e47\u0e2d\u0e28\u0e23\u0e35\u0e19"
+    ],
     "name:tur_x_preferred":[
         "Kassarin"
     ],
@@ -128,6 +134,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5361\u585e\u6797"
+    ],
+    "name:zul_x_preferred":[
+        "Kasserine"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Tunisia",
@@ -248,7 +257,7 @@
         }
     ],
     "wof:id":1141905995,
-    "wof:lastmodified":1636495673,
+    "wof:lastmodified":1690874872,
     "wof:name":"Kasserine",
     "wof:parent_id":1108757415,
     "wof:placetype":"locality",

--- a/data/114/190/599/7/1141905997.geojson
+++ b/data/114/190/599/7/1141905997.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"11.0408766153,35.4839130445,11.0408766153,35.4839130445",
+    "geom:bbox":"11.040877,35.483913,11.040877,35.483913",
     "geom:latitude":35.483913,
     "geom:longitude":11.040877,
     "iso:country":"TN",
@@ -51,7 +51,16 @@
     "name:ell_x_preferred":[
         "\u0391\u03bb \u039c\u03b1\u03bd\u03c4\u03af\u03b3\u03b9\u03b1"
     ],
+    "name:ell_x_variant":[
+        "\u039c\u03b1\u03c7\u03bd\u03c4\u03af\u03b1"
+    ],
     "name:eng_x_preferred":[
+        "Mahdia"
+    ],
+    "name:epo_x_preferred":[
+        "Mahdia"
+    ],
+    "name:eus_x_preferred":[
         "Mahdia"
     ],
     "name:fas_x_preferred":[
@@ -61,6 +70,9 @@
         "Mahdia"
     ],
     "name:fra_x_preferred":[
+        "Mahdia"
+    ],
+    "name:glg_x_preferred":[
         "Mahdia"
     ],
     "name:guj_x_preferred":[
@@ -108,8 +120,14 @@
     "name:nld_x_preferred":[
         "Mahdia"
     ],
+    "name:nno_x_preferred":[
+        "Mahdia"
+    ],
     "name:nob_x_preferred":[
         "Mahdia"
+    ],
+    "name:pnb_x_preferred":[
+        "\u0645\u06c1\u062f\u06cc\u06c1"
     ],
     "name:pol_x_preferred":[
         "Al-Mahdija"
@@ -138,6 +156,9 @@
     "name:spa_x_preferred":[
         "Mahdia"
     ],
+    "name:spa_x_variant":[
+        "Mahd\u00eda"
+    ],
     "name:swe_x_preferred":[
         "Mahdia"
     ],
@@ -149,6 +170,9 @@
     ],
     "name:tha_x_preferred":[
         "\u0e21\u0e32\u0e2b\u0e4c\u0e40\u0e14\u0e35\u0e22"
+    ],
+    "name:tha_x_variant":[
+        "\u0e2d\u0e31\u0e25\u0e21\u0e30\u0e2e\u0e4c\u0e14\u0e35\u0e22\u0e30\u0e2e\u0e4c"
     ],
     "name:tur_x_preferred":[
         "Mehdiye"
@@ -164,6 +188,9 @@
     ],
     "name:zho_x_preferred":[
         "\u9a6c\u8d6b\u8fea\u8036"
+    ],
+    "name:zul_x_preferred":[
+        "Mahdia"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Tunisia",
@@ -273,7 +300,7 @@
     },
     "wof:country":"TN",
     "wof:created":1499130527,
-    "wof:geomhash":"a2d50fbdebf5f4b388d8a351b3b02f94",
+    "wof:geomhash":"2fe0b93618e08b9099a111ad05650c71",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -284,7 +311,7 @@
         }
     ],
     "wof:id":1141905997,
-    "wof:lastmodified":1566667380,
+    "wof:lastmodified":1690874872,
     "wof:name":"Mahdia",
     "wof:parent_id":1108757481,
     "wof:placetype":"locality",
@@ -294,10 +321,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    11.04087661532196,
-    35.48391304450269,
-    11.04087661532196,
-    35.48391304450269
+    11.040877,
+    35.483913,
+    11.040877,
+    35.483913
 ],
-  "geometry": {"coordinates":[11.04087661532196,35.48391304450269],"type":"Point"}
+  "geometry": {"coordinates":[11.040877,35.483913],"type":"Point"}
 }

--- a/data/114/190/599/9/1141905999.geojson
+++ b/data/114/190/599/9/1141905999.geojson
@@ -21,6 +21,15 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0645\u0646\u0633\u062a\u064a\u0631"
     ],
+    "name:ary_x_preferred":[
+        "\u0644\u0645\u0646\u0633\u062a\u064a\u0631"
+    ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0645\u0646\u0633\u062a\u064a\u0631"
+    ],
+    "name:ast_x_preferred":[
+        "Monastir"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u0644\u0645\u0646\u0633\u062a\u06cc\u0631"
     ],
@@ -81,6 +90,9 @@
     "name:heb_x_preferred":[
         "\u05de\u05d5\u05e0\u05d0\u05e1\u05d8\u05d9\u05e8"
     ],
+    "name:heb_x_variant":[
+        "\u05de\u05d5\u05e0\u05e1\u05ea\u05d9\u05e8"
+    ],
     "name:hin_x_preferred":[
         "\u092e\u094b\u0928\u093e\u0938\u094d\u091f\u093f\u0930"
     ],
@@ -138,6 +150,9 @@
     "name:nob_x_preferred":[
         "Monastir"
     ],
+    "name:oss_x_preferred":[
+        "\u041c\u043e\u043d\u0430\u0441\u0442\u0438\u0440"
+    ],
     "name:pol_x_preferred":[
         "Monastyr"
     ],
@@ -177,6 +192,9 @@
     "name:tha_x_preferred":[
         "\u0e42\u0e21\u0e19\u0e32\u0e2a\u0e15\u0e35\u0e23\u0e4c"
     ],
+    "name:tha_x_variant":[
+        "\u0e2d\u0e31\u0e25\u0e21\u0e38\u0e19\u0e31\u0e2a\u0e15\u0e35\u0e23"
+    ],
     "name:tur_x_preferred":[
         "Munast\u0131r"
     ],
@@ -194,6 +212,9 @@
     ],
     "name:zho_x_preferred":[
         "\u83ab\u7eb3\u65af\u63d0\u5c14"
+    ],
+    "name:zul_x_preferred":[
+        "Monastir"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Tunisia",
@@ -314,7 +335,7 @@
         }
     ],
     "wof:id":1141905999,
-    "wof:lastmodified":1636495673,
+    "wof:lastmodified":1690874872,
     "wof:name":"Monastir",
     "wof:parent_id":1108757545,
     "wof:placetype":"locality",

--- a/data/114/190/684/9/1141906849.geojson
+++ b/data/114/190/684/9/1141906849.geojson
@@ -96,6 +96,9 @@
     "name:tur_x_preferred":[
         "Dehibat"
     ],
+    "name:tur_x_variant":[
+        "Dehiba"
+    ],
     "name:ukr_x_preferred":[
         "\u0417\u0435\u0445\u0456\u0431\u0430"
     ],
@@ -110,6 +113,9 @@
     ],
     "name:zho_tw_x_preferred":[
         "\u5fb7\u5e0c\u5df4\u7279"
+    ],
+    "name:zul_x_preferred":[
+        "Dehiba"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Tunisia",
@@ -230,7 +236,7 @@
         }
     ],
     "wof:id":1141906849,
-    "wof:lastmodified":1636495674,
+    "wof:lastmodified":1690874873,
     "wof:name":"Dehibat",
     "wof:parent_id":1108757721,
     "wof:placetype":"locality",

--- a/data/421/168/029/421168029.geojson
+++ b/data/421/168/029/421168029.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u062a\u0648\u0632\u0631"
     ],
+    "name:arz_x_preferred":[
+        "\u062a\u0648\u0632\u0631"
+    ],
     "name:azb_x_preferred":[
         "\u062a\u0648\u0632\u0631"
     ],
@@ -55,6 +58,9 @@
     ],
     "name:hun_x_preferred":[
         "Tozeur"
+    ],
+    "name:hun_x_variant":[
+        "Tauzer"
     ],
     "name:ind_x_preferred":[
         "Tozeur"
@@ -107,6 +113,9 @@
     "name:swe_x_preferred":[
         "Tozeur"
     ],
+    "name:tha_x_preferred":[
+        "\u0e40\u0e15\u0e32\u0e0b\u0e31\u0e23"
+    ],
     "name:tur_x_preferred":[
         "Tuzer"
     ],
@@ -118,6 +127,9 @@
     ],
     "name:zho_x_preferred":[
         "\u6258\u6cfd\u5c14"
+    ],
+    "name:zul_x_preferred":[
+        "Tozeur"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Tunisia",
@@ -258,7 +270,7 @@
         }
     ],
     "wof:id":421168029,
-    "wof:lastmodified":1566667302,
+    "wof:lastmodified":1690874840,
     "wof:name":"Tawzar",
     "wof:parent_id":1108757743,
     "wof:placetype":"locality",

--- a/data/421/169/017/421169017.geojson
+++ b/data/421/169/017/421169017.geojson
@@ -41,17 +41,26 @@
     "name:eng_x_preferred":[
         "Siliana"
     ],
+    "name:fas_x_preferred":[
+        "\u0633\u0644\u06cc\u0627\u0646\u0647"
+    ],
     "name:fra_x_preferred":[
         "Siliana"
     ],
     "name:gle_x_preferred":[
         "Siliana"
     ],
+    "name:heb_x_preferred":[
+        "\u05e1\u05d9\u05dc\u05d9\u05d0\u05e0\u05d4"
+    ],
     "name:hun_x_preferred":[
         "Siliana"
     ],
     "name:ita_x_preferred":[
         "Siliana"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30b7\u30ea\u30a2\u30ca"
     ],
     "name:kab_x_preferred":[
         "Silyana"
@@ -86,6 +95,9 @@
     "name:sco_x_preferred":[
         "Siliana"
     ],
+    "name:tha_x_preferred":[
+        "\u0e0b\u0e34\u0e25\u0e22\u0e32\u0e19\u0e30\u0e2e\u0e4c"
+    ],
     "name:tur_x_preferred":[
         "Silyana"
     ],
@@ -100,6 +112,9 @@
     ],
     "name:zho_x_preferred":[
         "\u932b\u52d2\u4e9e\u5948"
+    ],
+    "name:zul_x_preferred":[
+        "Siliana"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Tunisia",
@@ -243,7 +258,7 @@
         }
     ],
     "wof:id":421169017,
-    "wof:lastmodified":1566667304,
+    "wof:lastmodified":1690874842,
     "wof:name":"Silyanah",
     "wof:parent_id":1108757679,
     "wof:placetype":"locality",

--- a/data/421/169/019/421169019.geojson
+++ b/data/421/169/019/421169019.geojson
@@ -50,6 +50,9 @@
     "name:eng_x_preferred":[
         "Sidi Bouzid"
     ],
+    "name:est_x_preferred":[
+        "S\u012bd\u012b B\u016b Z\u012bd\u200e"
+    ],
     "name:fas_x_preferred":[
         "\u0633\u06cc\u062f\u06cc \u0628\u0648\u0632\u06cc\u062f"
     ],
@@ -107,6 +110,9 @@
     "name:swe_x_preferred":[
         "Sidi Bouzid"
     ],
+    "name:tha_x_preferred":[
+        "\u0e0b\u0e35\u0e14\u0e35\u0e1a\u0e39\u0e0b\u0e35\u0e14"
+    ],
     "name:tur_x_preferred":[
         "Sidi Bu Zeyd"
     ],
@@ -124,6 +130,9 @@
     ],
     "name:zho_x_preferred":[
         "\u897f\u8fea\u5e03\u6fdf\u5fb7"
+    ],
+    "name:zul_x_preferred":[
+        "Sidi Bouzid"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Tunisia",
@@ -264,7 +273,7 @@
         }
     ],
     "wof:id":421169019,
-    "wof:lastmodified":1566667304,
+    "wof:lastmodified":1690874843,
     "wof:name":"Sidi Bu Zayd",
     "wof:parent_id":1108757653,
     "wof:placetype":"locality",

--- a/data/421/169/021/421169021.geojson
+++ b/data/421/169/021/421169021.geojson
@@ -26,6 +26,9 @@
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u041d\u0430\u0431\u0443\u043b\u044c"
     ],
+    "name:bel_x_variant":[
+        "\u041d\u0430\u0431\u0443\u043b\u044c"
+    ],
     "name:cat_x_preferred":[
         "Nabeul"
     ],
@@ -73,6 +76,9 @@
     ],
     "name:hye_x_preferred":[
         "\u0546\u0561\u0562\u0578\u0582\u056c"
+    ],
+    "name:ind_x_preferred":[
+        "Nabeul"
     ],
     "name:ita_x_preferred":[
         "Nabeul"
@@ -122,6 +128,9 @@
     "name:swe_x_preferred":[
         "Nabeul"
     ],
+    "name:tha_x_preferred":[
+        "\u0e19\u0e32\u0e1a\u0e34\u0e25"
+    ],
     "name:tur_x_preferred":[
         "Nabil"
     ],
@@ -136,6 +145,9 @@
     ],
     "name:zho_x_preferred":[
         "\u7eb3\u5e03\u52d2"
+    ],
+    "name:zul_x_preferred":[
+        "Nabeul"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Tunisia",
@@ -278,7 +290,7 @@
         }
     ],
     "wof:id":421169021,
-    "wof:lastmodified":1566667304,
+    "wof:lastmodified":1690874843,
     "wof:name":"Nabul",
     "wof:parent_id":1108757589,
     "wof:placetype":"locality",

--- a/data/421/170/299/421170299.geojson
+++ b/data/421/170/299/421170299.geojson
@@ -29,14 +29,23 @@
     "name:eng_x_preferred":[
         "Goubellat"
     ],
+    "name:fas_x_preferred":[
+        "\u0642\u0628\u0644\u0627\u0637"
+    ],
     "name:fra_x_preferred":[
         "Goubellat"
     ],
     "name:nld_x_preferred":[
         "Goubellat"
     ],
+    "name:tur_x_preferred":[
+        "Kubellat"
+    ],
     "name:ukr_x_preferred":[
         "\u041a\u0443\u0431\u0435\u043b\u044f\u0442"
+    ],
+    "name:zul_x_preferred":[
+        "Goubellat"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -86,7 +95,7 @@
         }
     ],
     "wof:id":421170299,
-    "wof:lastmodified":1566667318,
+    "wof:lastmodified":1690874858,
     "wof:name":"Quballat",
     "wof:parent_id":1108757257,
     "wof:placetype":"locality",

--- a/data/421/170/757/421170757.geojson
+++ b/data/421/170/757/421170757.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0628\u0646\u0642\u0631\u062f\u0627\u0646"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0646\u0642\u0631\u062f\u0627\u0646"
+    ],
     "name:azb_x_preferred":[
         "\u0628\u0646 \u0642\u0631\u062f\u0627\u0646"
     ],
@@ -35,8 +38,14 @@
     "name:cym_x_preferred":[
         "Ben Guerdane"
     ],
+    "name:dan_x_preferred":[
+        "Ben Gardane"
+    ],
     "name:deu_x_preferred":[
         "Ben Gardane"
+    ],
+    "name:ell_x_preferred":[
+        "\u039c\u03c0\u03b5\u03bd \u0393\u03ba\u03b5\u03c1\u03bd\u03c4\u03ac\u03bd"
     ],
     "name:eng_x_preferred":[
         "Ben Gardane"
@@ -44,17 +53,35 @@
     "name:fas_x_preferred":[
         "\u0628\u0646 \u0642\u0631\u062f\u0627\u0646"
     ],
+    "name:fin_x_preferred":[
+        "Ben Gardane"
+    ],
     "name:fra_x_preferred":[
         "Ben Gardane"
+    ],
+    "name:heb_x_preferred":[
+        "\u05d1\u05df \u05d2\u05e8\u05d3\u05d0\u05df"
     ],
     "name:hun_x_preferred":[
         "Ben Gardane"
     ],
+    "name:hun_x_variant":[
+        "Bengard\u00e1n"
+    ],
     "name:ita_x_preferred":[
+        "Ben Gardane"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30d9\u30f3\u30ab\u30eb\u30c0\u30f3"
+    ],
+    "name:kab_x_preferred":[
         "Ben Gardane"
     ],
     "name:kor_x_preferred":[
         "\ubca4\uac00\ub974\ub2e8"
+    ],
+    "name:lit_x_preferred":[
+        "Ben Gardanas"
     ],
     "name:nld_x_preferred":[
         "Ben Gardane"
@@ -65,6 +92,9 @@
     "name:por_x_preferred":[
         "Ben Gardane"
     ],
+    "name:ron_x_preferred":[
+        "Ben Gardane"
+    ],
     "name:rus_x_preferred":[
         "\u0411\u0435\u043d-\u0413\u0430\u0440\u0434\u0430\u043d"
     ],
@@ -72,6 +102,9 @@
         "Ben Gardane"
     ],
     "name:spa_x_preferred":[
+        "Ben Gardane"
+    ],
+    "name:tur_x_preferred":[
         "Ben Gardane"
     ],
     "name:ukr_x_preferred":[
@@ -85,6 +118,9 @@
     ],
     "name:zho_x_preferred":[
         "\u672c\u52a0\u723e\u4e39"
+    ],
+    "name:zul_x_preferred":[
+        "Ben Gardane"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Tunisia",
@@ -228,7 +264,7 @@
         }
     ],
     "wof:id":421170757,
-    "wof:lastmodified":1566667318,
+    "wof:lastmodified":1690874857,
     "wof:name":"Bin Qirdan",
     "wof:parent_id":1108757509,
     "wof:placetype":"locality",

--- a/data/421/170/761/421170761.geojson
+++ b/data/421/170/761/421170761.geojson
@@ -23,6 +23,9 @@
     "name:azb_x_preferred":[
         "\u0627\u0644\u0645\u0633\u062f\u0648\u0631"
     ],
+    "name:cat_x_preferred":[
+        "El Masdour"
+    ],
     "name:ceb_x_preferred":[
         "Al Ma\u015fd\u016br"
     ],
@@ -38,11 +41,17 @@
     "name:nld_x_preferred":[
         "El Masdour"
     ],
+    "name:tur_x_preferred":[
+        "El-Mesdur"
+    ],
     "name:ukr_x_preferred":[
         "\u0415\u043b\u044c-\u041c\u0430\u0441\u0434\u0443\u0440"
     ],
     "name:und_x_variant":[
         "Mesdour"
+    ],
+    "name:zul_x_preferred":[
+        "El Masdour"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -92,7 +101,7 @@
         }
     ],
     "wof:id":421170761,
-    "wof:lastmodified":1566667318,
+    "wof:lastmodified":1690874858,
     "wof:name":"Al Masdur",
     "wof:parent_id":1108757533,
     "wof:placetype":"locality",

--- a/data/421/170/763/421170763.geojson
+++ b/data/421/170/763/421170763.geojson
@@ -41,17 +41,26 @@
     "name:eng_x_preferred":[
         "Haffouz"
     ],
+    "name:fas_x_preferred":[
+        "\u062d\u0641\u0648\u0632"
+    ],
     "name:fra_x_preferred":[
         "Haffouz"
     ],
     "name:nld_x_preferred":[
         "Haffouz"
     ],
+    "name:tur_x_preferred":[
+        "Hafuz"
+    ],
     "name:ukr_x_preferred":[
         "\u0425\u0430\u0444\u0444\u0443\u0437"
     ],
     "name:und_x_variant":[
         "Pichon"
+    ],
+    "name:zul_x_preferred":[
+        "Haffouz"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -101,7 +110,7 @@
         }
     ],
     "wof:id":421170763,
-    "wof:lastmodified":1566667317,
+    "wof:lastmodified":1690874857,
     "wof:name":"Haffuz",
     "wof:parent_id":1108757383,
     "wof:placetype":"locality",

--- a/data/421/172/885/421172885.geojson
+++ b/data/421/172/885/421172885.geojson
@@ -35,17 +35,29 @@
     "name:eng_x_preferred":[
         "Chebba"
     ],
+    "name:fas_x_preferred":[
+        "\u0627\u0644\u0634\u0627\u0628\u0647"
+    ],
     "name:fra_x_preferred":[
         "Chebba"
     ],
+    "name:hau_x_preferred":[
+        "Grain Chebba"
+    ],
     "name:ita_x_preferred":[
         "Chebba"
+    ],
+    "name:lit_x_preferred":[
+        "\u0160eba"
     ],
     "name:nld_x_preferred":[
         "Chebba"
     ],
     "name:ron_x_preferred":[
         "Chebba"
+    ],
+    "name:tur_x_preferred":[
+        "\u015eebba"
     ],
     "name:ukr_x_preferred":[
         "\u0428\u0435\u0431\u0431\u0430"
@@ -55,6 +67,9 @@
     ],
     "name:zho_x_preferred":[
         "\u6c99\u62dc"
+    ],
+    "name:zul_x_preferred":[
+        "Chebba"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -103,7 +118,7 @@
         }
     ],
     "wof:id":421172885,
-    "wof:lastmodified":1566667311,
+    "wof:lastmodified":1690874849,
     "wof:name":"Ash Shabbah",
     "wof:parent_id":1108757469,
     "wof:placetype":"locality",

--- a/data/421/173/137/421173137.geojson
+++ b/data/421/173/137/421173137.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0634\u0628\u064a\u0643\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0634\u0628\u064a\u0643\u0647"
+    ],
     "name:cat_x_preferred":[
         "Oasi de Chebika"
     ],
@@ -101,7 +104,7 @@
         }
     ],
     "wof:id":421173137,
-    "wof:lastmodified":1566667310,
+    "wof:lastmodified":1690874848,
     "wof:name":"Shabikah",
     "wof:parent_id":1108757741,
     "wof:placetype":"locality",

--- a/data/421/173/175/421173175.geojson
+++ b/data/421/173/175/421173175.geojson
@@ -17,11 +17,26 @@
     "mz:is_current":1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:afr_x_preferred":[
+        "Medenine"
+    ],
     "name:ara_x_preferred":[
         "\u0645\u062f\u0646\u064a\u0646"
     ],
+    "name:arg_x_preferred":[
+        "Medenine"
+    ],
+    "name:ast_x_preferred":[
+        "Medenine"
+    ],
     "name:azb_x_preferred":[
         "\u0645\u062f\u0646\u06cc\u0646"
+    ],
+    "name:bar_x_preferred":[
+        "Medenine"
+    ],
+    "name:bre_x_preferred":[
+        "Medenine"
     ],
     "name:bul_x_preferred":[
         "\u041c\u0435\u0434\u0435\u043d\u0438\u043d\u0435"
@@ -30,6 +45,12 @@
         "M\u00e9denine"
     ],
     "name:ceb_x_preferred":[
+        "Medenine"
+    ],
+    "name:ces_x_preferred":[
+        "Madan\u00edn"
+    ],
+    "name:cos_x_preferred":[
         "Medenine"
     ],
     "name:cym_x_preferred":[
@@ -50,6 +71,15 @@
     "name:eng_x_preferred":[
         "Medenine"
     ],
+    "name:epo_x_preferred":[
+        "Medenine"
+    ],
+    "name:est_x_preferred":[
+        "Medenine"
+    ],
+    "name:eus_x_preferred":[
+        "Medenine"
+    ],
     "name:fas_x_preferred":[
         "\u0645\u062f\u0646\u06cc\u0646"
     ],
@@ -59,8 +89,50 @@
     "name:fra_x_preferred":[
         "M\u00e9denine"
     ],
+    "name:frp_x_preferred":[
+        "Medenine"
+    ],
+    "name:fur_x_preferred":[
+        "Medenine"
+    ],
+    "name:gla_x_preferred":[
+        "Medenine"
+    ],
+    "name:gle_x_preferred":[
+        "Medenine"
+    ],
+    "name:glg_x_preferred":[
+        "Medenine"
+    ],
+    "name:gsw_x_preferred":[
+        "Medenine"
+    ],
+    "name:heb_x_preferred":[
+        "\u05de\u05d3\u05e0\u05d9\u05df"
+    ],
+    "name:hrv_x_preferred":[
+        "Medenine"
+    ],
     "name:hun_x_preferred":[
         "M\u00e9denine"
+    ],
+    "name:hun_x_variant":[
+        "Meden\u00edn"
+    ],
+    "name:ido_x_preferred":[
+        "Medenine"
+    ],
+    "name:ile_x_preferred":[
+        "Medenine"
+    ],
+    "name:ina_x_preferred":[
+        "Medenine"
+    ],
+    "name:ind_x_preferred":[
+        "Medenine"
+    ],
+    "name:isl_x_preferred":[
+        "Medenine"
     ],
     "name:ita_x_preferred":[
         "Medenina"
@@ -71,14 +143,59 @@
     "name:kab_x_preferred":[
         "Mednin"
     ],
+    "name:kon_x_preferred":[
+        "Medenine"
+    ],
     "name:kor_x_preferred":[
         "\uba54\ub4dc\ub2cc"
+    ],
+    "name:lij_x_preferred":[
+        "Medenine"
+    ],
+    "name:lim_x_preferred":[
+        "Medenine"
     ],
     "name:lit_x_preferred":[
         "Medeninas"
     ],
+    "name:ltz_x_preferred":[
+        "Medenine"
+    ],
+    "name:min_x_preferred":[
+        "Medenine"
+    ],
+    "name:mlg_x_preferred":[
+        "Medenine"
+    ],
+    "name:msa_x_preferred":[
+        "Medenine"
+    ],
+    "name:nap_x_preferred":[
+        "Medenine"
+    ],
+    "name:nds_x_preferred":[
+        "Medenine"
+    ],
     "name:nld_x_preferred":[
         "M\u00e9denine"
+    ],
+    "name:nno_x_preferred":[
+        "Medenine"
+    ],
+    "name:nob_x_preferred":[
+        "Medenine"
+    ],
+    "name:nrm_x_preferred":[
+        "Medenine"
+    ],
+    "name:oci_x_preferred":[
+        "Medenine"
+    ],
+    "name:pcd_x_preferred":[
+        "Medenine"
+    ],
+    "name:pms_x_preferred":[
+        "Medenine"
     ],
     "name:pol_x_preferred":[
         "Madanin"
@@ -86,17 +203,41 @@
     "name:por_x_preferred":[
         "M\u00e9denine"
     ],
+    "name:roh_x_preferred":[
+        "Medenine"
+    ],
     "name:ron_x_preferred":[
         "Medenine"
     ],
     "name:rus_x_preferred":[
         "\u041c\u0435\u0434\u0435\u043d\u0438\u043d"
     ],
+    "name:scn_x_preferred":[
+        "Medenine"
+    ],
     "name:sco_x_preferred":[
+        "Medenine"
+    ],
+    "name:slk_x_preferred":[
+        "Medenine"
+    ],
+    "name:slv_x_preferred":[
         "Medenine"
     ],
     "name:spa_x_preferred":[
         "M\u00e9denine"
+    ],
+    "name:srd_x_preferred":[
+        "Medenine"
+    ],
+    "name:swa_x_preferred":[
+        "Medenine"
+    ],
+    "name:swe_x_preferred":[
+        "Medenine"
+    ],
+    "name:tha_x_preferred":[
+        "\u0e21\u0e30\u0e14\u0e30\u0e19\u0e35\u0e19"
     ],
     "name:tur_x_preferred":[
         "Medenin"
@@ -110,8 +251,29 @@
     "name:urd_x_preferred":[
         "\u0645\u062f\u0646\u06cc\u0646"
     ],
+    "name:vec_x_preferred":[
+        "Medenine"
+    ],
+    "name:vie_x_preferred":[
+        "Medenine"
+    ],
+    "name:vls_x_preferred":[
+        "Medenine"
+    ],
+    "name:vol_x_preferred":[
+        "Medenine"
+    ],
+    "name:wln_x_preferred":[
+        "Medenine"
+    ],
+    "name:wol_x_preferred":[
+        "Medenine"
+    ],
     "name:zho_x_preferred":[
         "\u6885\u5fb7\u5be7"
+    ],
+    "name:zul_x_preferred":[
+        "Medenine"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPLA",
@@ -162,7 +324,7 @@
         }
     ],
     "wof:id":421173175,
-    "wof:lastmodified":1566667310,
+    "wof:lastmodified":1690874848,
     "wof:name":"Madanin",
     "wof:parent_id":1108757521,
     "wof:placetype":"locality",

--- a/data/421/173/177/421173177.geojson
+++ b/data/421/173/177/421173177.geojson
@@ -62,6 +62,9 @@
     "name:rus_x_preferred":[
         "\u041c\u0438\u0434\u0443\u043d"
     ],
+    "name:tur_x_preferred":[
+        "Midun"
+    ],
     "name:ukr_x_preferred":[
         "\u041c\u0456\u0434\u0443\u043d"
     ],
@@ -70,6 +73,9 @@
     ],
     "name:urd_x_preferred":[
         "\u0645\u06cc\u062f\u0648\u0646"
+    ],
+    "name:zul_x_preferred":[
+        "Midoun"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -119,7 +125,7 @@
         }
     ],
     "wof:id":421173177,
-    "wof:lastmodified":1566667310,
+    "wof:lastmodified":1690874848,
     "wof:name":"Midun",
     "wof:parent_id":1108757519,
     "wof:placetype":"locality",

--- a/data/421/173/179/421173179.geojson
+++ b/data/421/173/179/421173179.geojson
@@ -32,6 +32,9 @@
     "name:cat_x_preferred":[
         "La Goulette"
     ],
+    "name:cat_x_variant":[
+        "La Goleta"
+    ],
     "name:ceb_x_preferred":[
         "La Goulette"
     ],
@@ -57,6 +60,9 @@
         "\u062d\u0644\u0642 \u0627\u0644\u0648\u0627\u062f\u06cc"
     ],
     "name:fra_x_preferred":[
+        "La Goulette"
+    ],
+    "name:gle_x_preferred":[
         "La Goulette"
     ],
     "name:glg_x_preferred":[
@@ -98,6 +104,12 @@
     "name:nld_x_preferred":[
         "La Goulette"
     ],
+    "name:nob_x_preferred":[
+        "La Goulette"
+    ],
+    "name:oci_x_preferred":[
+        "La Goleta"
+    ],
     "name:pol_x_preferred":[
         "Halk al-Wadi"
     ],
@@ -122,6 +134,9 @@
     "name:swe_x_preferred":[
         "La Goulette"
     ],
+    "name:tur_x_preferred":[
+        "Halk\u00fc'l-Vadi"
+    ],
     "name:ukr_x_preferred":[
         "\u041b\u0430-\u0490\u0443\u043b\u0454\u0442"
     ],
@@ -133,6 +148,9 @@
     ],
     "name:zho_x_preferred":[
         "\u62c9\u53e4\u83b1\u7279"
+    ],
+    "name:zul_x_preferred":[
+        "La Goulette"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -181,7 +199,7 @@
         }
     ],
     "wof:id":421173179,
-    "wof:lastmodified":1566667310,
+    "wof:lastmodified":1690874849,
     "wof:name":"Halq al Wadi",
     "wof:parent_id":1108757755,
     "wof:placetype":"locality",

--- a/data/421/173/529/421173529.geojson
+++ b/data/421/173/529/421173529.geojson
@@ -35,6 +35,9 @@
     "name:cym_x_preferred":[
         "Soliman"
     ],
+    "name:dan_x_preferred":[
+        "Soliman"
+    ],
     "name:deu_x_preferred":[
         "Soliman"
     ],
@@ -53,14 +56,26 @@
     "name:jpn_x_preferred":[
         "\u30bd\u30ea\u30de\u30f3"
     ],
+    "name:lit_x_preferred":[
+        "Solimanas"
+    ],
     "name:ron_x_preferred":[
         "Soliman"
+    ],
+    "name:swe_x_preferred":[
+        "Soliman"
+    ],
+    "name:tur_x_preferred":[
+        "S\u00fcleyman"
     ],
     "name:ukr_x_preferred":[
         "\u0421\u043e\u043b\u0456\u043c\u0430\u043d"
     ],
     "name:und_x_variant":[
         "Gumis"
+    ],
+    "name:zul_x_preferred":[
+        "Soliman"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -109,7 +124,7 @@
         }
     ],
     "wof:id":421173529,
-    "wof:lastmodified":1566667309,
+    "wof:lastmodified":1690874848,
     "wof:name":"Sulayman",
     "wof:parent_id":1108757591,
     "wof:placetype":"locality",

--- a/data/421/174/075/421174075.geojson
+++ b/data/421/174/075/421174075.geojson
@@ -41,6 +41,9 @@
     "name:deu_x_preferred":[
         "Tabarca"
     ],
+    "name:ell_x_preferred":[
+        "\u0398\u03b1\u03cd\u03b2\u03c1\u03b1\u03ba\u03b1"
+    ],
     "name:eng_x_preferred":[
         "Tabarka"
     ],
@@ -55,6 +58,9 @@
     ],
     "name:fra_x_preferred":[
         "Tabarka"
+    ],
+    "name:heb_x_preferred":[
+        "\u05d8\u05d1\u05e8\u05e7\u05d4"
     ],
     "name:ita_x_preferred":[
         "Tabarka"
@@ -104,8 +110,14 @@
     "name:und_x_variant":[
         "Thabraca"
     ],
+    "name:urd_x_preferred":[
+        "\u0637\u0628\u0631\u0642\u06c1"
+    ],
     "name:zho_x_preferred":[
         "\u5854\u5df4\u5361"
+    ],
+    "name:zul_x_preferred":[
+        "Tabarka"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -157,7 +169,7 @@
         }
     ],
     "wof:id":421174075,
-    "wof:lastmodified":1566667308,
+    "wof:lastmodified":1690874847,
     "wof:name":"Tabarqah",
     "wof:parent_id":1108757373,
     "wof:placetype":"locality",

--- a/data/421/174/083/421174083.geojson
+++ b/data/421/174/083/421174083.geojson
@@ -22,6 +22,9 @@
     "name:ben_x_preferred":[
         "\u09b8\u09c7\u09a8\u09cd\u099f-\u099c\u09b0\u09cd\u099c\u09c7\u09b8"
     ],
+    "name:deu_x_preferred":[
+        "Lafayette"
+    ],
     "name:ell_x_preferred":[
         "\u03a3\u03b1\u03bd-\u0396\u03bf\u03c1\u03b6"
     ],
@@ -48,6 +51,9 @@
     ],
     "name:kor_x_preferred":[
         "\uc138\uc778\ud2b8 \uc870\uc9c0\uc2a4"
+    ],
+    "name:nld_x_preferred":[
+        "Lafayette"
     ],
     "name:ukr_x_preferred":[
         "\u0421\u0435\u0439\u043d\u0442-\u0414\u0436\u043e\u0440\u0434\u0436\u0435\u0441"
@@ -101,7 +107,7 @@
         }
     ],
     "wof:id":421174083,
-    "wof:lastmodified":1636495672,
+    "wof:lastmodified":1690874846,
     "wof:name":"Saint-Georges",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/421/174/087/421174087.geojson
+++ b/data/421/174/087/421174087.geojson
@@ -53,6 +53,12 @@
     "name:pol_x_preferred":[
         "Sukra"
     ],
+    "name:rus_x_preferred":[
+        "\u041b\u0430 \u0421\u043e\u0443\u043a\u0440\u0430"
+    ],
+    "name:tur_x_preferred":[
+        "Sukra"
+    ],
     "name:ukr_x_preferred":[
         "\u0421\u0443\u043a\u0440\u0430"
     ],
@@ -61,6 +67,9 @@
     ],
     "name:urd_x_preferred":[
         "\u0633\u06a9\u0631\u06c1"
+    ],
+    "name:zul_x_preferred":[
+        "La Soukra"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -116,7 +125,7 @@
         }
     ],
     "wof:id":421174087,
-    "wof:lastmodified":1566667308,
+    "wof:lastmodified":1690874847,
     "wof:name":"Sukrah",
     "wof:parent_id":1108757249,
     "wof:placetype":"locality",

--- a/data/421/174/331/421174331.geojson
+++ b/data/421/174/331/421174331.geojson
@@ -32,7 +32,13 @@
     "name:eng_x_preferred":[
         "Remada"
     ],
+    "name:fas_x_preferred":[
+        "\u0631\u0645\u0627\u062f\u0647"
+    ],
     "name:fra_x_preferred":[
+        "Remada"
+    ],
+    "name:hun_x_preferred":[
         "Remada"
     ],
     "name:ind_x_preferred":[
@@ -59,7 +65,16 @@
     "name:ron_x_preferred":[
         "Remada"
     ],
+    "name:rus_x_preferred":[
+        "\u0420\u0435\u043c\u0430\u0434\u0430"
+    ],
     "name:sco_x_preferred":[
+        "Remada"
+    ],
+    "name:sqi_x_preferred":[
+        "Remada"
+    ],
+    "name:tur_x_preferred":[
         "Remada"
     ],
     "name:ukr_x_preferred":[
@@ -67,6 +82,9 @@
     ],
     "name:und_x_variant":[
         "Ram\u0101dah"
+    ],
+    "name:zul_x_preferred":[
+        "Remada"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -116,7 +134,7 @@
         }
     ],
     "wof:id":421174331,
-    "wof:lastmodified":1566667307,
+    "wof:lastmodified":1690874846,
     "wof:name":"Ramadah",
     "wof:parent_id":1108757725,
     "wof:placetype":"locality",

--- a/data/421/174/939/421174939.geojson
+++ b/data/421/174/939/421174939.geojson
@@ -23,6 +23,15 @@
     "name:ara_x_variant":[
         "\u0645\u0646\u0633\u062a\u064a\u0631"
     ],
+    "name:ary_x_preferred":[
+        "\u0644\u0645\u0646\u0633\u062a\u064a\u0631"
+    ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0645\u0646\u0633\u062a\u064a\u0631"
+    ],
+    "name:ast_x_preferred":[
+        "Monastir"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u0644\u0645\u0646\u0633\u062a\u06cc\u0631"
     ],
@@ -86,6 +95,9 @@
     "name:heb_x_preferred":[
         "\u05de\u05d5\u05e0\u05d0\u05e1\u05d8\u05d9\u05e8"
     ],
+    "name:heb_x_variant":[
+        "\u05de\u05d5\u05e0\u05e1\u05ea\u05d9\u05e8"
+    ],
     "name:hin_x_preferred":[
         "\u092e\u094b\u0928\u093e\u0938\u094d\u091f\u093f\u0930"
     ],
@@ -140,6 +152,9 @@
     "name:nob_x_preferred":[
         "Monastir"
     ],
+    "name:oss_x_preferred":[
+        "\u041c\u043e\u043d\u0430\u0441\u0442\u0438\u0440"
+    ],
     "name:pol_x_preferred":[
         "Monastyr"
     ],
@@ -179,6 +194,9 @@
     "name:tha_x_preferred":[
         "\u0e42\u0e21\u0e19\u0e32\u0e2a\u0e15\u0e35\u0e23\u0e4c"
     ],
+    "name:tha_x_variant":[
+        "\u0e2d\u0e31\u0e25\u0e21\u0e38\u0e19\u0e31\u0e2a\u0e15\u0e35\u0e23"
+    ],
     "name:tur_x_preferred":[
         "Munast\u0131r"
     ],
@@ -199,6 +217,9 @@
     ],
     "name:zho_x_preferred":[
         "\u83ab\u7eb3\u65af\u63d0\u5c14"
+    ],
+    "name:zul_x_preferred":[
+        "Monastir"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPLA",
@@ -248,7 +269,7 @@
         }
     ],
     "wof:id":421174939,
-    "wof:lastmodified":1566667307,
+    "wof:lastmodified":1690874846,
     "wof:name":"Al Munastir",
     "wof:parent_id":1108757545,
     "wof:placetype":"locality",

--- a/data/421/174/941/421174941.geojson
+++ b/data/421/174/941/421174941.geojson
@@ -32,6 +32,9 @@
     "name:cym_x_preferred":[
         "La Marsa"
     ],
+    "name:dan_x_preferred":[
+        "La Marsa"
+    ],
     "name:deu_x_preferred":[
         "La Marsa"
     ],
@@ -55,6 +58,9 @@
     ],
     "name:hun_x_preferred":[
         "La Marsa"
+    ],
+    "name:hun_x_variant":[
+        "el-Marsza"
     ],
     "name:hye_x_preferred":[
         "\u053c\u0561 \u0544\u0561\u0580\u057d\u0561"
@@ -95,6 +101,12 @@
     "name:spa_x_preferred":[
         "La Marsa"
     ],
+    "name:szl_x_preferred":[
+        "La Marsa"
+    ],
+    "name:tur_x_preferred":[
+        "El-Marsa"
+    ],
     "name:ukr_x_preferred":[
         "\u041b\u0430-\u041c\u0430\u0440\u0441\u0430"
     ],
@@ -106,6 +118,9 @@
     ],
     "name:zho_x_preferred":[
         "\u62c9\u99ac\u723e\u85a9"
+    ],
+    "name:zul_x_preferred":[
+        "La Marsa"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -155,7 +170,7 @@
         }
     ],
     "wof:id":421174941,
-    "wof:lastmodified":1566667307,
+    "wof:lastmodified":1690874846,
     "wof:name":"Al Marsa",
     "wof:parent_id":1108757755,
     "wof:placetype":"locality",

--- a/data/421/174/943/421174943.geojson
+++ b/data/421/174/943/421174943.geojson
@@ -62,6 +62,9 @@
     "name:kor_x_preferred":[
         "\uc790\ub974\uc9c0\uc2a4"
     ],
+    "name:lit_x_preferred":[
+        "Zarzisas"
+    ],
     "name:nld_x_preferred":[
         "Zarzis"
     ],
@@ -83,6 +86,9 @@
     "name:sco_x_preferred":[
         "Zarzis"
     ],
+    "name:tur_x_preferred":[
+        "Carcis"
+    ],
     "name:ukr_x_preferred":[
         "\u0417\u0430\u0440\u0437\u0456\u0441"
     ],
@@ -94,6 +100,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5091\u723e\u5409\u65af"
+    ],
+    "name:zul_x_preferred":[
+        "Zarzis"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Tunisia",
@@ -237,7 +246,7 @@
         }
     ],
     "wof:id":421174943,
-    "wof:lastmodified":1566667308,
+    "wof:lastmodified":1690874847,
     "wof:name":"Jarjis",
     "wof:parent_id":1108757527,
     "wof:placetype":"locality",

--- a/data/421/175/985/421175985.geojson
+++ b/data/421/175/985/421175985.geojson
@@ -26,6 +26,9 @@
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0411\u0435\u0434\u0436\u0430"
     ],
+    "name:bel_x_variant":[
+        "\u0411\u0435\u0434\u0436\u0430"
+    ],
     "name:ben_x_preferred":[
         "\u09ac\u09c7\u099c\u09be"
     ],
@@ -65,14 +68,23 @@
     "name:gle_x_preferred":[
         "B\u00e9ja"
     ],
+    "name:grc_x_preferred":[
+        "\u039f\u1f50\u03ac\u03b3\u03b1"
+    ],
     "name:guj_x_preferred":[
         "\u0aac\u0ac7\u0a9c\u0abe"
+    ],
+    "name:heb_x_preferred":[
+        "\u05d1\u05d6'\u05d4"
     ],
     "name:hin_x_preferred":[
         "\u092c\u0947\u0916\u093e"
     ],
     "name:hun_x_preferred":[
         "B\u00e9ja"
+    ],
+    "name:hun_x_variant":[
+        "Bezsa"
     ],
     "name:ind_x_preferred":[
         "B\u00e9ja"
@@ -91,6 +103,9 @@
     ],
     "name:kor_x_preferred":[
         "\ubca0\uc790"
+    ],
+    "name:lat_x_preferred":[
+        "Vacca"
     ],
     "name:lav_x_preferred":[
         "Bed\u017ea"
@@ -146,6 +161,9 @@
     "name:tha_x_preferred":[
         "\u0e40\u0e1a\u0e08\u0e32"
     ],
+    "name:tha_x_variant":[
+        "\u0e1a\u0e32\u0e0d\u0e30\u0e2e\u0e4c"
+    ],
     "name:tur_x_preferred":[
         "Bace"
     ],
@@ -163,6 +181,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5df4\u6770"
+    ],
+    "name:zul_x_preferred":[
+        "B\u00e9ja"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Tunisia",
@@ -302,7 +323,7 @@
         }
     ],
     "wof:id":421175985,
-    "wof:lastmodified":1566667312,
+    "wof:lastmodified":1690874850,
     "wof:name":"Bajah",
     "wof:parent_id":1108757253,
     "wof:placetype":"locality",

--- a/data/421/175/987/421175987.geojson
+++ b/data/421/175/987/421175987.geojson
@@ -62,6 +62,12 @@
     "name:hun_x_preferred":[
         "Kasszerine"
     ],
+    "name:hye_x_preferred":[
+        "\u053f\u0561\u057d\u0565\u0580\u056b\u0576"
+    ],
+    "name:ind_x_preferred":[
+        "Kasserine"
+    ],
     "name:ita_x_preferred":[
         "Kasserine"
     ],
@@ -101,6 +107,9 @@
     "name:swe_x_preferred":[
         "Kasserine"
     ],
+    "name:tha_x_preferred":[
+        "\u0e2d\u0e31\u0e25\u0e01\u0e47\u0e2d\u0e28\u0e23\u0e35\u0e19"
+    ],
     "name:tur_x_preferred":[
         "Kassarin"
     ],
@@ -115,6 +124,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5361\u585e\u6797"
+    ],
+    "name:zul_x_preferred":[
+        "Kasserine"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Tunisia",
@@ -255,7 +267,7 @@
         }
     ],
     "wof:id":421175987,
-    "wof:lastmodified":1566667312,
+    "wof:lastmodified":1690874851,
     "wof:name":"Al Qasrayn",
     "wof:parent_id":1108757415,
     "wof:placetype":"locality",

--- a/data/421/176/075/421176075.geojson
+++ b/data/421/176/075/421176075.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0642\u0645\u0631\u062a"
     ],
+    "name:arz_x_preferred":[
+        "\u0642\u0645\u0631\u062a"
+    ],
     "name:cat_x_preferred":[
         "Gammarth"
     ],
@@ -28,6 +31,9 @@
     ],
     "name:deu_x_preferred":[
         "Gammarth"
+    ],
+    "name:ell_x_preferred":[
+        "\u0393\u03ba\u03b1\u03bc\u03ac\u03c1\u03c4"
     ],
     "name:eng_x_preferred":[
         "Gammarth"
@@ -115,7 +121,7 @@
         }
     ],
     "wof:id":421176075,
-    "wof:lastmodified":1566667323,
+    "wof:lastmodified":1690874864,
     "wof:name":"Qamart",
     "wof:parent_id":1108757755,
     "wof:placetype":"locality",

--- a/data/421/177/263/421177263.geojson
+++ b/data/421/177/263/421177263.geojson
@@ -35,6 +35,9 @@
     "name:eng_x_preferred":[
         "Thala"
     ],
+    "name:fas_x_preferred":[
+        "\u062a\u0627\u0644\u0647"
+    ],
     "name:fin_x_preferred":[
         "Thala"
     ],
@@ -50,11 +53,20 @@
     "name:nld_x_preferred":[
         "Thala"
     ],
+    "name:rus_x_preferred":[
+        "\u0422\u0430\u043b\u0430"
+    ],
+    "name:tur_x_preferred":[
+        "Tala"
+    ],
     "name:ukr_x_preferred":[
         "\u0422\u0430\u043b\u0430"
     ],
     "name:und_x_variant":[
         "Tala"
+    ],
+    "name:zul_x_preferred":[
+        "Thala"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -104,7 +116,7 @@
         }
     ],
     "wof:id":421177263,
-    "wof:lastmodified":1566667318,
+    "wof:lastmodified":1690874858,
     "wof:name":"Talah",
     "wof:parent_id":1108757427,
     "wof:placetype":"locality",

--- a/data/421/177/731/421177731.geojson
+++ b/data/421/177/731/421177731.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0641\u0637\u0646\u0627\u0633\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0641\u0637\u0646\u0627\u0633\u0647"
+    ],
     "name:deu_x_preferred":[
         "Fatnassa"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":421177731,
-    "wof:lastmodified":1566667318,
+    "wof:lastmodified":1690874858,
     "wof:name":"Fitnasah",
     "wof:parent_id":1108757441,
     "wof:placetype":"locality",

--- a/data/421/178/245/421178245.geojson
+++ b/data/421/178/245/421178245.geojson
@@ -23,6 +23,9 @@
     "name:cat_x_preferred":[
         "Raf Raf"
     ],
+    "name:ceb_x_preferred":[
+        "Rafr\u0101f"
+    ],
     "name:deu_x_preferred":[
         "Raf Raf"
     ],
@@ -31,6 +34,9 @@
     ],
     "name:eng_x_preferred":[
         "Raf Raf"
+    ],
+    "name:fas_x_preferred":[
+        "\u0631\u0641\u0631\u0627\u0641"
     ],
     "name:fra_x_preferred":[
         "Raf Raf"
@@ -43,6 +49,9 @@
     ],
     "name:ukr_x_preferred":[
         "\u0420\u0430\u0444\u0440\u0430\u0444"
+    ],
+    "name:zul_x_preferred":[
+        "Raf Raf"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -91,7 +100,7 @@
         }
     ],
     "wof:id":421178245,
-    "wof:lastmodified":1566667320,
+    "wof:lastmodified":1690874860,
     "wof:name":"Rafraf",
     "wof:parent_id":1108757301,
     "wof:placetype":"locality",

--- a/data/421/178/249/421178249.geojson
+++ b/data/421/178/249/421178249.geojson
@@ -47,6 +47,9 @@
     "name:fra_x_preferred":[
         "Rad\u00e8s"
     ],
+    "name:heb_x_preferred":[
+        "\u05e8\u05d3\u05e1"
+    ],
     "name:hun_x_preferred":[
         "Rad\u00e8s"
     ],
@@ -110,6 +113,9 @@
     "name:zho_x_preferred":[
         "\u62c9\u8fea\u65af"
     ],
+    "name:zul_x_preferred":[
+        "Rad\u00e8s"
+    ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
     "qs:gn_id":2467815,
@@ -160,7 +166,7 @@
         }
     ],
     "wof:id":421178249,
-    "wof:lastmodified":1566667321,
+    "wof:lastmodified":1690874862,
     "wof:name":"Radis",
     "wof:parent_id":1108757271,
     "wof:placetype":"locality",

--- a/data/421/178/253/421178253.geojson
+++ b/data/421/178/253/421178253.geojson
@@ -29,8 +29,14 @@
     "name:azb_x_preferred":[
         "\u0635\u06cc\u0627\u062f\u0647"
     ],
+    "name:cat_x_preferred":[
+        "Sayada"
+    ],
     "name:ceb_x_preferred":[
         "A\u015f \u015eayy\u0101dah"
+    ],
+    "name:deu_x_preferred":[
+        "Sayada"
     ],
     "name:eng_x_preferred":[
         "Sayada"
@@ -56,10 +62,19 @@
     "name:spa_x_preferred":[
         "Sayada"
     ],
+    "name:tur_x_preferred":[
+        "Sayada"
+    ],
     "name:ukr_x_preferred":[
         "\u0421\u0430\u044f\u0434\u0430"
     ],
     "name:vie_x_preferred":[
+        "Sayada"
+    ],
+    "name:zho_x_preferred":[
+        "\u6c99\u8036\u9054"
+    ],
+    "name:zul_x_preferred":[
         "Sayada"
     ],
     "qs:gn_country":"TN",
@@ -110,7 +125,7 @@
         }
     ],
     "wof:id":421178253,
-    "wof:lastmodified":1566667321,
+    "wof:lastmodified":1690874862,
     "wof:name":"As Sayyadah",
     "wof:parent_id":1108757553,
     "wof:placetype":"locality",

--- a/data/421/178/255/421178255.geojson
+++ b/data/421/178/255/421178255.geojson
@@ -23,6 +23,12 @@
     "name:cat_x_preferred":[
         "Sened"
     ],
+    "name:ceb_x_preferred":[
+        "As Sanad"
+    ],
+    "name:deu_x_preferred":[
+        "Sened"
+    ],
     "name:eng_x_preferred":[
         "Sened"
     ],
@@ -35,8 +41,14 @@
     "name:nld_x_preferred":[
         "Sened"
     ],
+    "name:tur_x_preferred":[
+        "Sened"
+    ],
     "name:ukr_x_preferred":[
         "\u0421\u0430\u043d\u0430\u0434"
+    ],
+    "name:zul_x_preferred":[
+        "Sened"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -85,7 +97,7 @@
         }
     ],
     "wof:id":421178255,
-    "wof:lastmodified":1566667322,
+    "wof:lastmodified":1690874862,
     "wof:name":"As Sanad",
     "wof:parent_id":1108757351,
     "wof:placetype":"locality",

--- a/data/421/178/845/421178845.geojson
+++ b/data/421/178/845/421178845.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u062a\u0645\u063a\u0632\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u062a\u0645\u063a\u0632\u0647"
+    ],
     "name:bul_x_preferred":[
         "\u0422\u0430\u043c\u0430\u0433\u0445\u0437\u0430\u0445"
     ],
@@ -56,8 +59,14 @@
     "name:sco_x_preferred":[
         "Tamerza"
     ],
+    "name:tur_x_preferred":[
+        "Tama\u011fza"
+    ],
     "name:ukr_x_preferred":[
         "\u0422\u0430\u043c\u0435\u0491\u0437\u0430"
+    ],
+    "name:zul_x_preferred":[
+        "Tamerza"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -106,7 +115,7 @@
         }
     ],
     "wof:id":421178845,
-    "wof:lastmodified":1566667320,
+    "wof:lastmodified":1690874860,
     "wof:name":"Tamaghzah",
     "wof:parent_id":1108757741,
     "wof:placetype":"locality",

--- a/data/421/178/847/421178847.geojson
+++ b/data/421/178/847/421178847.geojson
@@ -47,14 +47,23 @@
     "name:hun_x_preferred":[
         "T\u00e9boursouk"
     ],
+    "name:hun_x_variant":[
+        "Teburszuk"
+    ],
     "name:kab_x_preferred":[
         "Tabursuq"
+    ],
+    "name:tur_x_preferred":[
+        "Tabursuk"
     ],
     "name:ukr_x_preferred":[
         "\u0422\u0435\u0431\u0443\u0440\u0441\u0443\u043a"
     ],
     "name:und_x_variant":[
         "Teboursouk"
+    ],
+    "name:zul_x_preferred":[
+        "T\u00e9boursouk"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -103,7 +112,7 @@
         }
     ],
     "wof:id":421178847,
-    "wof:lastmodified":1566667321,
+    "wof:lastmodified":1690874861,
     "wof:name":"Tabursuq",
     "wof:parent_id":1108757265,
     "wof:placetype":"locality",

--- a/data/421/178/849/421178849.geojson
+++ b/data/421/178/849/421178849.geojson
@@ -20,20 +20,35 @@
     "name:ara_x_preferred":[
         "\u0645\u0646\u0632\u0644 \u0639\u0628\u062f \u0627\u0644\u0631\u062d\u0645\u0627\u0646"
     ],
+    "name:cat_x_preferred":[
+        "Menzel Abderrahmen"
+    ],
     "name:ceb_x_preferred":[
         "Menzel Abderhaman"
+    ],
+    "name:deu_x_preferred":[
+        "Menzel Abderrahmane"
     ],
     "name:eng_x_preferred":[
         "Menzel Abderrahmane"
     ],
+    "name:fas_x_preferred":[
+        "\u0645\u0646\u0632\u0644 \u0639\u0628\u062f \u0627\u0644\u0631\u062d\u0645\u0627\u0646"
+    ],
     "name:fra_x_preferred":[
         "Menzel Abderrahmane"
+    ],
+    "name:tur_x_preferred":[
+        "Menzil Abdurrahman"
     ],
     "name:ukr_x_preferred":[
         "\u041c\u0435\u043d\u0437\u0435\u043b\u044c-\u0410\u0431\u0434\u0435\u0440\u0440\u0430\u0445\u043c\u0430\u043d"
     ],
     "name:und_x_variant":[
         "Mennzel-Abd-er-Ralmane"
+    ],
+    "name:zul_x_preferred":[
+        "Menzel Abderrahmane"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -81,7 +96,7 @@
         }
     ],
     "wof:id":421178849,
-    "wof:lastmodified":1566667321,
+    "wof:lastmodified":1690874861,
     "wof:name":"Manzil Abd ar Rahman",
     "wof:parent_id":1108757299,
     "wof:placetype":"locality",

--- a/data/421/178/851/421178851.geojson
+++ b/data/421/178/851/421178851.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0645\u0643\u062b\u0631"
     ],
+    "name:arz_x_preferred":[
+        "\u0645\u0643\u062b\u0631"
+    ],
     "name:bul_x_preferred":[
         "\u041c\u0430\u043a\u0442\u0430\u0440"
     ],
@@ -38,8 +41,14 @@
     "name:eng_x_preferred":[
         "Maktar"
     ],
+    "name:fas_x_preferred":[
+        "\u0645\u06a9\u062b\u0631"
+    ],
     "name:fra_x_preferred":[
         "Makthar"
+    ],
+    "name:heb_x_preferred":[
+        "\u05de\u05db\u05ea\u05e8"
     ],
     "name:hun_x_preferred":[
         "Maktar"
@@ -65,6 +74,12 @@
     "name:ron_x_preferred":[
         "Makthar"
     ],
+    "name:rus_x_preferred":[
+        "\u041c\u0430\u043a\u0442\u0430\u0440"
+    ],
+    "name:tur_x_preferred":[
+        "Mukasir"
+    ],
     "name:ukr_x_preferred":[
         "\u041c\u0430\u043a\u0441\u0430\u0440"
     ],
@@ -73,6 +88,9 @@
     ],
     "name:zho_x_preferred":[
         "\u51ef\u9c81\u4e07"
+    ],
+    "name:zul_x_preferred":[
+        "Maktar"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -122,7 +140,7 @@
         }
     ],
     "wof:id":421178851,
-    "wof:lastmodified":1566667320,
+    "wof:lastmodified":1690874860,
     "wof:name":"Makthar",
     "wof:parent_id":1108757675,
     "wof:placetype":"locality",

--- a/data/421/178/853/421178853.geojson
+++ b/data/421/178/853/421178853.geojson
@@ -50,8 +50,14 @@
     "name:fra_x_preferred":[
         "Houmt Souk"
     ],
+    "name:heb_x_preferred":[
+        "\u05d7\u05de\u05ea \u05e9\u05d5\u05e7"
+    ],
     "name:hun_x_preferred":[
         "Houmt-Souk"
+    ],
+    "name:hun_x_variant":[
+        "H\u00famat esz-Sz\u00fak"
     ],
     "name:ita_x_preferred":[
         "Houmt Souk"
@@ -77,8 +83,17 @@
     "name:rus_x_preferred":[
         "\u0425\u0443\u043c\u0442-\u0421\u0443\u043a"
     ],
+    "name:spa_x_preferred":[
+        "Houmt El Souk"
+    ],
+    "name:tur_x_preferred":[
+        "Humet\u00fc's-Suk"
+    ],
     "name:ukr_x_preferred":[
         "\u0425\u0443\u043c\u0442-\u0421\u0443\u043a"
+    ],
+    "name:ukr_x_variant":[
+        "\u0413\u0443\u043c\u0442-\u0421\u0443\u043a"
     ],
     "name:und_x_variant":[
         "\u1e28awmat as S\u016bq"
@@ -88,6 +103,9 @@
     ],
     "name:zho_x_preferred":[
         "\u8c6a\u9081\u7279\u8607\u683c"
+    ],
+    "name:zul_x_preferred":[
+        "Houmt El Souk"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -136,7 +154,7 @@
         }
     ],
     "wof:id":421178853,
-    "wof:lastmodified":1566667321,
+    "wof:lastmodified":1690874862,
     "wof:name":"Hawmat as Suq",
     "wof:parent_id":1108757517,
     "wof:placetype":"locality",

--- a/data/421/178/855/421178855.geojson
+++ b/data/421/178/855/421178855.geojson
@@ -38,6 +38,12 @@
     "name:cym_x_preferred":[
         "Hammam Sousse"
     ],
+    "name:dan_x_preferred":[
+        "Hammam Sousse"
+    ],
+    "name:deu_x_preferred":[
+        "Hammam Sousse"
+    ],
     "name:ell_x_preferred":[
         "\u03a7\u03b1\u03bc\u03ac\u03bc \u03a3\u03bf\u03c5\u03c2"
     ],
@@ -83,6 +89,9 @@
     "name:rus_x_preferred":[
         "\u0425\u0430\u043c\u043c\u0430\u043c \u0421\u0443\u0441"
     ],
+    "name:rus_x_variant":[
+        "\u0425\u0430\u043c\u043c\u0430\u043c-\u0421\u0443\u0441"
+    ],
     "name:sco_x_preferred":[
         "Hammam Sousse"
     ],
@@ -92,11 +101,26 @@
     "name:slv_x_preferred":[
         "Hammam Sousse"
     ],
+    "name:swe_x_preferred":[
+        "Hammam Sousse"
+    ],
+    "name:szl_x_preferred":[
+        "Hammam Susa"
+    ],
+    "name:tur_x_preferred":[
+        "Hamam Susa"
+    ],
     "name:ukr_x_preferred":[
         "\u0425\u0430\u043c\u043c\u0430\u043c-\u0421\u0443\u0441"
     ],
     "name:und_x_variant":[
         "Justiniapolis"
+    ],
+    "name:urd_x_preferred":[
+        "\u062d\u0645\u0627\u0645 \u0633\u0648\u0633\u06c1"
+    ],
+    "name:zul_x_preferred":[
+        "Hammam Sousse"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -146,7 +170,7 @@
         }
     ],
     "wof:id":421178855,
-    "wof:lastmodified":1566667322,
+    "wof:lastmodified":1690874862,
     "wof:name":"Hammam Susah",
     "wof:parent_id":1108757689,
     "wof:placetype":"locality",

--- a/data/421/178/871/421178871.geojson
+++ b/data/421/178/871/421178871.geojson
@@ -26,6 +26,9 @@
     "name:ceb_x_preferred":[
         "Tataouine"
     ],
+    "name:ces_x_preferred":[
+        "Tataouine"
+    ],
     "name:cym_x_preferred":[
         "Tataouine"
     ],
@@ -55,6 +58,9 @@
     ],
     "name:hun_x_preferred":[
         "Tataouine"
+    ],
+    "name:hun_x_variant":[
+        "Tat\u00e1v\u00edn"
     ],
     "name:ita_x_preferred":[
         "Tataouine"
@@ -86,8 +92,14 @@
     "name:sco_x_preferred":[
         "Tataouine"
     ],
+    "name:spa_x_preferred":[
+        "Tataouine"
+    ],
     "name:swe_x_preferred":[
         "Tataouine"
+    ],
+    "name:tha_x_preferred":[
+        "\u0e15\u0e30\u0e0f\u0e2d\u0e27\u0e35\u0e19"
     ],
     "name:tur_x_preferred":[
         "Tatavin"
@@ -103,6 +115,9 @@
     ],
     "name:zho_x_preferred":[
         "\u6cf0\u5854\u6eab"
+    ],
+    "name:zul_x_preferred":[
+        "Tataouine"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Tunisia",
@@ -246,7 +261,7 @@
         }
     ],
     "wof:id":421178871,
-    "wof:lastmodified":1566667321,
+    "wof:lastmodified":1690874861,
     "wof:name":"Tatawin",
     "wof:parent_id":1108757731,
     "wof:placetype":"locality",

--- a/data/421/178/873/421178873.geojson
+++ b/data/421/178/873/421178873.geojson
@@ -20,14 +20,26 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0642\u064a\u0631\u0648\u0627\u0646"
     ],
+    "name:ary_x_preferred":[
+        "\u0627\u0644\u0642\u064a\u0631\u0648\u0627\u0646"
+    ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0642\u064a\u0631\u0648\u0627\u0646"
+    ],
     "name:ast_x_preferred":[
         "Kairu\u00e1n"
     ],
     "name:azb_x_preferred":[
         "\u0642\u06cc\u0631\u0648\u0627\u0646"
     ],
+    "name:aze_x_preferred":[
+        "Qeyr\u0259van"
+    ],
     "name:bak_x_preferred":[
         "\u041a\u0430\u0440\u0443\u0430\u043d"
+    ],
+    "name:bak_x_variant":[
+        "\u04a0\u0430\u0439\u0440\u0430\u04af\u04d9\u043d"
     ],
     "name:bel_x_preferred":[
         "\u041a\u0430\u0439\u0440\u0443\u0430\u043d"
@@ -62,8 +74,14 @@
     "name:deu_x_preferred":[
         "Qairaw\u0101n"
     ],
+    "name:deu_x_variant":[
+        "Kairouan"
+    ],
     "name:ell_x_preferred":[
         "\u039a\u03b1\u03ca\u03c1\u03bf\u03c5\u03ac\u03bd"
+    ],
+    "name:ell_x_variant":[
+        "\u039a\u03b1\u03ca\u03c1\u03b1\u03bf\u03c5\u03ac\u03bd"
     ],
     "name:eng_x_preferred":[
         "Kairouan"
@@ -152,6 +170,9 @@
     "name:mar_x_preferred":[
         "\u0915\u0947\u0905\u0930\u094c\u0906\u0928"
     ],
+    "name:mlt_x_preferred":[
+        "Kairouan"
+    ],
     "name:msa_x_preferred":[
         "Kairouan"
     ],
@@ -206,6 +227,9 @@
     "name:srp_x_variant":[
         "\u041a\u0435\u0440\u0443\u0430\u043d"
     ],
+    "name:swa_x_preferred":[
+        "Kairuan"
+    ],
     "name:swe_x_preferred":[
         "Kairouan"
     ],
@@ -218,8 +242,14 @@
     "name:tha_x_preferred":[
         "\u0e44\u0e04\u0e23\u0e27\u0e19"
     ],
+    "name:tha_x_variant":[
+        "\u0e2d\u0e31\u0e25\u0e01\u0e47\u0e2d\u0e22\u0e40\u0e23\u0e32\u0e30\u0e27\u0e32\u0e19"
+    ],
     "name:tur_x_preferred":[
         "Kayravan"
+    ],
+    "name:uig_x_preferred":[
+        "\u0642\u06d5\u064a\u0631\u06d5\u06cb\u0627\u0646"
     ],
     "name:ukr_x_preferred":[
         "\u041a\u0430\u0439\u0440\u0443\u0430\u043d"
@@ -233,14 +263,23 @@
     "name:uzb_x_preferred":[
         "Qayruvon"
     ],
+    "name:uzb_x_variant":[
+        "Qayravon"
+    ],
     "name:vie_x_preferred":[
         "Kairouan"
     ],
     "name:war_x_preferred":[
         "Kairouan"
     ],
+    "name:wuu_x_preferred":[
+        "\u51ef\u9c81\u4e07"
+    ],
     "name:zho_x_preferred":[
         "\u51ef\u9c81\u4e07"
+    ],
+    "name:zul_x_preferred":[
+        "Kairouan"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Tunisia",
@@ -381,7 +420,7 @@
         }
     ],
     "wof:id":421178873,
-    "wof:lastmodified":1566667320,
+    "wof:lastmodified":1690874860,
     "wof:name":"Al Qayrawan",
     "wof:parent_id":1108757389,
     "wof:placetype":"locality",

--- a/data/421/178/969/421178969.geojson
+++ b/data/421/178/969/421178969.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u062f\u0642\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u062f\u0642\u0647"
+    ],
     "name:ast_x_preferred":[
         "Dougga"
     ],
@@ -54,6 +57,9 @@
         "Dougga"
     ],
     "name:fra_x_preferred":[
+        "Dougga"
+    ],
+    "name:glg_x_preferred":[
         "Dougga"
     ],
     "name:hbs_x_preferred":[
@@ -175,7 +181,7 @@
         }
     ],
     "wof:id":421178969,
-    "wof:lastmodified":1566667320,
+    "wof:lastmodified":1690874861,
     "wof:name":"Dougga",
     "wof:parent_id":1108757265,
     "wof:placetype":"locality",

--- a/data/421/181/177/421181177.geojson
+++ b/data/421/181/177/421181177.geojson
@@ -35,8 +35,14 @@
     "name:eng_x_preferred":[
         "A\u00efn Draham"
     ],
+    "name:fas_x_preferred":[
+        "\u0639\u06cc\u0646 \u062f\u0631\u0627\u0647\u0645"
+    ],
     "name:fra_x_preferred":[
         "A\u00efn Draham"
+    ],
+    "name:heb_x_preferred":[
+        "\u05e2\u05d9\u05df \u05d3\u05e8\u05d4\u05dd"
     ],
     "name:ita_x_preferred":[
         "A\u00efn Draham"
@@ -53,11 +59,20 @@
     "name:por_x_preferred":[
         "A\u00efn Draham"
     ],
+    "name:spa_x_preferred":[
+        "A\u00efn Draham"
+    ],
+    "name:tur_x_preferred":[
+        "Ayn Drahim"
+    ],
     "name:ukr_x_preferred":[
         "\u0410\u0439\u043d-\u0414\u0440\u0430\u0445\u0430\u043c"
     ],
     "name:und_x_variant":[
         "A\u00efne Draham"
+    ],
+    "name:zul_x_preferred":[
+        "A\u00efn Draham"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -105,7 +120,7 @@
         }
     ],
     "wof:id":421181177,
-    "wof:lastmodified":1566667312,
+    "wof:lastmodified":1690874850,
     "wof:name":"Ayn ad Darahim",
     "wof:parent_id":1108757355,
     "wof:placetype":"locality",

--- a/data/421/181/461/421181461.geojson
+++ b/data/421/181/461/421181461.geojson
@@ -44,6 +44,9 @@
     "name:fra_x_preferred":[
         "Douz"
     ],
+    "name:heb_x_preferred":[
+        "\u05d3\u05d5\u05d6"
+    ],
     "name:ita_x_preferred":[
         "Douz"
     ],
@@ -55,6 +58,9 @@
     ],
     "name:nob_x_preferred":[
         "Slaget om Douz"
+    ],
+    "name:nob_x_variant":[
+        "Douz"
     ],
     "name:nor_x_preferred":[
         "Slaget om Douz"
@@ -74,6 +80,9 @@
     "name:sco_x_preferred":[
         "Douz"
     ],
+    "name:tur_x_preferred":[
+        "Duz"
+    ],
     "name:ukr_x_preferred":[
         "\u0414\u0443\u0437"
     ],
@@ -82,6 +91,9 @@
     ],
     "name:zho_x_preferred":[
         "\u675c\u8332"
+    ],
+    "name:zul_x_preferred":[
+        "Douz"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -131,7 +143,7 @@
         }
     ],
     "wof:id":421181461,
-    "wof:lastmodified":1566667312,
+    "wof:lastmodified":1690874850,
     "wof:name":"Doz",
     "wof:parent_id":1108757429,
     "wof:placetype":"locality",

--- a/data/421/181/851/421181851.geojson
+++ b/data/421/181/851/421181851.geojson
@@ -26,6 +26,9 @@
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u041c\u0441\u0430\u043a\u0435\u043d"
     ],
+    "name:bel_x_variant":[
+        "\u041c\u0441\u0430\u043a\u0435\u043d"
+    ],
     "name:cat_x_preferred":[
         "M'Saken"
     ],
@@ -80,11 +83,20 @@
     "name:spa_x_preferred":[
         "M'saken"
     ],
+    "name:szl_x_preferred":[
+        "M'saken"
+    ],
+    "name:tur_x_preferred":[
+        "Mesakin"
+    ],
     "name:ukr_x_preferred":[
         "\u041c\u0441\u0430\u043a\u0435\u043d"
     ],
     "name:zho_x_preferred":[
         "\u59c6\u85a9\u80af"
+    ],
+    "name:zul_x_preferred":[
+        "M'saken"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -136,7 +148,7 @@
         }
     ],
     "wof:id":421181851,
-    "wof:lastmodified":1566667312,
+    "wof:lastmodified":1690874849,
     "wof:name":"Masakin",
     "wof:parent_id":1108757701,
     "wof:placetype":"locality",

--- a/data/421/181/853/421181853.geojson
+++ b/data/421/181/853/421181853.geojson
@@ -35,8 +35,14 @@
     "name:eng_x_preferred":[
         "Menzel Jemil"
     ],
+    "name:fas_x_preferred":[
+        "\u0645\u0646\u0632\u0644 \u062c\u0645\u06cc\u0644"
+    ],
     "name:fra_x_preferred":[
         "Menzel Jemil"
+    ],
+    "name:rus_x_preferred":[
+        "\u041c\u0435\u043d\u0437\u0435\u043b\u044c-\u0414\u0436\u0435\u043c\u0438\u043b\u044c"
     ],
     "name:swe_x_preferred":[
         "Menzel Jemil"
@@ -46,6 +52,9 @@
     ],
     "name:und_x_variant":[
         "Djemil"
+    ],
+    "name:zul_x_preferred":[
+        "Menzel Jemil"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -95,7 +104,7 @@
         }
     ],
     "wof:id":421181853,
-    "wof:lastmodified":1566667312,
+    "wof:lastmodified":1690874849,
     "wof:name":"Manzil Jamil",
     "wof:parent_id":1108757299,
     "wof:placetype":"locality",

--- a/data/421/181/855/421181855.geojson
+++ b/data/421/181/855/421181855.geojson
@@ -26,8 +26,14 @@
     "name:ceb_x_preferred":[
         "Dar Chabanne"
     ],
+    "name:deu_x_preferred":[
+        "Dar Chaabane"
+    ],
     "name:eng_x_preferred":[
         "Dar Chaabane"
+    ],
+    "name:fas_x_preferred":[
+        "\u062f\u0627\u0631 \u0634\u0639\u0628\u0627\u0646 \u0627\u0644\u0641\u0647\u0631\u06cc"
     ],
     "name:fra_x_preferred":[
         "Dar Cha\u00e2bane"
@@ -41,8 +47,14 @@
     "name:nld_x_preferred":[
         "Dar Chaabane"
     ],
+    "name:tur_x_preferred":[
+        "Dar \u015eaban"
+    ],
     "name:und_x_variant":[
         "Dar-Chaabane-el-Fehri"
+    ],
+    "name:zul_x_preferred":[
+        "Dar Chaabane"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -92,7 +104,7 @@
         }
     ],
     "wof:id":421181855,
-    "wof:lastmodified":1566667312,
+    "wof:lastmodified":1690874850,
     "wof:name":"Dar Shaban",
     "wof:parent_id":1108757567,
     "wof:placetype":"locality",

--- a/data/421/182/187/421182187.geojson
+++ b/data/421/182/187/421182187.geojson
@@ -26,6 +26,9 @@
     "name:eng_x_preferred":[
         "Hiboun"
     ],
+    "name:fas_x_preferred":[
+        "\u0647\u06cc\u0628\u0648\u0646"
+    ],
     "name:fra_x_preferred":[
         "Hiboun"
     ],
@@ -85,7 +88,7 @@
         }
     ],
     "wof:id":421182187,
-    "wof:lastmodified":1566667322,
+    "wof:lastmodified":1690874863,
     "wof:name":"Hibun",
     "wof:parent_id":1108757481,
     "wof:placetype":"locality",

--- a/data/421/182/193/421182193.geojson
+++ b/data/421/182/193/421182193.geojson
@@ -32,6 +32,9 @@
     "name:cat_x_preferred":[
         "K\u00e9libia"
     ],
+    "name:ceb_x_preferred":[
+        "Qulayb\u012byah"
+    ],
     "name:cym_x_preferred":[
         "Kelibia"
     ],
@@ -49,6 +52,9 @@
     ],
     "name:hun_x_preferred":[
         "Kelibia"
+    ],
+    "name:hye_x_preferred":[
+        "\u053f\u0565\u056c\u056b\u0562\u056b\u0561"
     ],
     "name:ita_x_preferred":[
         "K\u00e9libia"
@@ -86,6 +92,9 @@
     "name:swe_x_preferred":[
         "Kelibia"
     ],
+    "name:tur_x_preferred":[
+        "Kalbiye"
+    ],
     "name:ukr_x_preferred":[
         "\u041a\u0435\u043b\u0456\u0431\u0456\u044f"
     ],
@@ -97,6 +106,9 @@
     ],
     "name:zho_x_preferred":[
         "\u53e4\u840a\u6bd4\u8036"
+    ],
+    "name:zul_x_preferred":[
+        "Kelibia"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -145,7 +157,7 @@
         }
     ],
     "wof:id":421182193,
-    "wof:lastmodified":1566667322,
+    "wof:lastmodified":1690874863,
     "wof:name":"Qulaybiyah",
     "wof:parent_id":1108757579,
     "wof:placetype":"locality",

--- a/data/421/182/673/421182673.geojson
+++ b/data/421/182/673/421182673.geojson
@@ -41,6 +41,9 @@
     "name:eng_x_preferred":[
         "Skhira"
     ],
+    "name:fas_x_preferred":[
+        "\u0627\u0644\u0635\u062e\u06cc\u0631\u0647"
+    ],
     "name:fra_x_preferred":[
         "Skhira"
     ],
@@ -59,14 +62,23 @@
     "name:rus_x_preferred":[
         "\u0428\u0445\u0438\u0440\u0430"
     ],
+    "name:rus_x_variant":[
+        "\u0421\u0435\u0445\u0438\u0440\u0430"
+    ],
     "name:sco_x_preferred":[
         "Skhira"
+    ],
+    "name:tur_x_preferred":[
+        "Suheyre"
     ],
     "name:ukr_x_preferred":[
         "\u0421\u0445\u0456\u0440\u0430"
     ],
     "name:und_x_variant":[
         "Cekhira"
+    ],
+    "name:zul_x_preferred":[
+        "Skhira"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -115,7 +127,7 @@
         }
     ],
     "wof:id":421182673,
-    "wof:lastmodified":1566667322,
+    "wof:lastmodified":1690874863,
     "wof:name":"As Sukhayrah",
     "wof:parent_id":1108757627,
     "wof:placetype":"locality",

--- a/data/421/182/767/421182767.geojson
+++ b/data/421/182/767/421182767.geojson
@@ -32,6 +32,9 @@
     "name:eng_x_preferred":[
         "Mateur"
     ],
+    "name:fas_x_preferred":[
+        "\u0645\u0627\u0637\u0631"
+    ],
     "name:fra_x_preferred":[
         "Mateur"
     ],
@@ -52,6 +55,9 @@
     ],
     "name:und_x_variant":[
         "Matem"
+    ],
+    "name:zul_x_preferred":[
+        "Mateur"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -101,7 +107,7 @@
         }
     ],
     "wof:id":421182767,
-    "wof:lastmodified":1566667322,
+    "wof:lastmodified":1690874863,
     "wof:name":"Matir",
     "wof:parent_id":1108757293,
     "wof:placetype":"locality",

--- a/data/421/182/769/421182769.geojson
+++ b/data/421/182/769/421182769.geojson
@@ -59,11 +59,17 @@
     "name:swe_x_preferred":[
         "Leptis minor"
     ],
+    "name:tur_x_preferred":[
+        "Lemta"
+    ],
     "name:ukr_x_preferred":[
         "\u041b\u044f\u043c\u0442\u0430"
     ],
     "name:zho_x_preferred":[
         "\u862d\u9054\u93ae"
+    ],
+    "name:zul_x_preferred":[
+        "Lemta"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -113,7 +119,7 @@
         }
     ],
     "wof:id":421182769,
-    "wof:lastmodified":1566667322,
+    "wof:lastmodified":1690874863,
     "wof:name":"Lamtah",
     "wof:parent_id":1108757553,
     "wof:placetype":"locality",

--- a/data/421/183/533/421183533.geojson
+++ b/data/421/183/533/421183533.geojson
@@ -32,6 +32,9 @@
     "name:eng_x_preferred":[
         "Bir Ali Ben Kh\u00e9lifa"
     ],
+    "name:fas_x_preferred":[
+        "\u0628\u0626\u0631 \u0639\u0644\u06cc \u0628\u0646 \u062e\u0644\u06cc\u0641\u0647"
+    ],
     "name:fra_x_preferred":[
         "Bir Ali Ben Khalifa"
     ],
@@ -44,8 +47,14 @@
     "name:nld_x_preferred":[
         "Bir Ali Ben Kh\u00e9lifa"
     ],
+    "name:tur_x_preferred":[
+        "Bir Ali bin Halife"
+    ],
     "name:ukr_x_preferred":[
         "\u0411\u0435\u0435\u0440-\u0410\u043b\u0456-\u0411\u0435\u043d-\u0425\u0430\u043b\u0456\u0444\u0430"
+    ],
+    "name:zul_x_preferred":[
+        "Bir Ali Ben Kh\u00e9lifa"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -95,7 +104,7 @@
         }
     ],
     "wof:id":421183533,
-    "wof:lastmodified":1566667318,
+    "wof:lastmodified":1690874858,
     "wof:name":"Bi'r Ali Bin Khalifah",
     "wof:parent_id":1108757597,
     "wof:placetype":"locality",

--- a/data/421/183/535/421183535.geojson
+++ b/data/421/183/535/421183535.geojson
@@ -32,6 +32,9 @@
     "name:eng_x_preferred":[
         "Bir El Hafey"
     ],
+    "name:fas_x_preferred":[
+        "\u0628\u0626\u0631 \u0627\u0644\u062d\u0641\u06cc"
+    ],
     "name:fra_x_preferred":[
         "Bir El Hafey"
     ],
@@ -41,11 +44,17 @@
     "name:nld_x_preferred":[
         "Bir El Hafey"
     ],
+    "name:tur_x_preferred":[
+        "Bir\u00fc'l-Hafiy"
+    ],
     "name:ukr_x_preferred":[
         "\u0411\u0435\u0435\u0440-\u0435\u043b\u044c-\u0425\u0430\u0444\u0435\u0439"
     ],
     "name:und_x_variant":[
         "Bir el Afey"
+    ],
+    "name:zul_x_preferred":[
+        "Bir El Hafey"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -97,7 +106,7 @@
         }
     ],
     "wof:id":421183535,
-    "wof:lastmodified":1566667319,
+    "wof:lastmodified":1690874859,
     "wof:name":"Bi'r al Hufayy",
     "wof:parent_id":1108757631,
     "wof:placetype":"locality",

--- a/data/421/183/537/421183537.geojson
+++ b/data/421/183/537/421183537.geojson
@@ -23,6 +23,15 @@
     "name:azb_x_preferred":[
         "\u0637\u0648\u0632\u0647"
     ],
+    "name:cat_x_preferred":[
+        "Touza"
+    ],
+    "name:ceb_x_preferred":[
+        "\u0162\u016bzah"
+    ],
+    "name:deu_x_preferred":[
+        "Touza"
+    ],
     "name:eng_x_preferred":[
         "Touza"
     ],
@@ -41,8 +50,14 @@
     "name:spa_x_preferred":[
         "Touza"
     ],
+    "name:tur_x_preferred":[
+        "Tavza"
+    ],
     "name:ukr_x_preferred":[
         "\u0422\u0443\u0437\u0430"
+    ],
+    "name:zul_x_preferred":[
+        "Touza"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -90,7 +105,7 @@
         }
     ],
     "wof:id":421183537,
-    "wof:lastmodified":1566667319,
+    "wof:lastmodified":1690874859,
     "wof:name":"Tuzah",
     "wof:parent_id":1108757541,
     "wof:placetype":"locality",

--- a/data/421/183/753/421183753.geojson
+++ b/data/421/183/753/421183753.geojson
@@ -35,6 +35,9 @@
     "name:eng_x_preferred":[
         "Ghomrassen"
     ],
+    "name:fas_x_preferred":[
+        "\u063a\u0645\u0631\u0627\u0633\u0646"
+    ],
     "name:fra_x_preferred":[
         "Ghomrassen"
     ],
@@ -53,11 +56,17 @@
     "name:sco_x_preferred":[
         "Ghomrassen"
     ],
+    "name:tur_x_preferred":[
+        "Gamarasin"
+    ],
     "name:ukr_x_preferred":[
         "\u0413\u043e\u043c\u0440\u0430\u0441\u0441\u0435\u043d"
     ],
     "name:und_x_variant":[
         "Rhoumerassen"
+    ],
+    "name:zul_x_preferred":[
+        "Ghomrassen"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -106,7 +115,7 @@
         }
     ],
     "wof:id":421183753,
-    "wof:lastmodified":1566667318,
+    "wof:lastmodified":1690874859,
     "wof:name":"Ghumrasin",
     "wof:parent_id":1108757723,
     "wof:placetype":"locality",

--- a/data/421/183/759/421183759.geojson
+++ b/data/421/183/759/421183759.geojson
@@ -35,11 +35,17 @@
     "name:eng_x_preferred":[
         "Ha\u00efdra"
     ],
+    "name:fas_x_preferred":[
+        "\u062d\u06cc\u062f\u0631\u0647"
+    ],
     "name:fin_x_preferred":[
         "Ha\u00efdra"
     ],
     "name:fra_x_preferred":[
         "Ha\u00efdra"
+    ],
+    "name:heb_x_preferred":[
+        "\u05d7\u05d9\u05d3\u05e8\u05d4"
     ],
     "name:ita_x_preferred":[
         "Haidra"
@@ -50,11 +56,23 @@
     "name:por_x_preferred":[
         "Ha\u00efdra"
     ],
+    "name:rus_x_preferred":[
+        "\u0425\u0430\u0439\u0434\u0440\u0430"
+    ],
+    "name:spa_x_preferred":[
+        "Ha\u00efdra"
+    ],
+    "name:tur_x_preferred":[
+        "Haydare"
+    ],
     "name:ukr_x_preferred":[
         "\u0413\u0456\u0434\u0440\u0430"
     ],
     "name:und_x_variant":[
         "Hennchir Ha\u00efdra"
+    ],
+    "name:zul_x_preferred":[
+        "Ha\u00efdra"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -103,7 +121,7 @@
         }
     ],
     "wof:id":421183759,
-    "wof:lastmodified":1566667320,
+    "wof:lastmodified":1690874859,
     "wof:name":"Haidra",
     "wof:parent_id":1108757411,
     "wof:placetype":"locality",

--- a/data/421/183/851/421183851.geojson
+++ b/data/421/183/851/421183851.geojson
@@ -19,14 +19,29 @@
     "name:ara_x_preferred":[
         "\u0628\u0627\u0628 \u0627\u0644\u062e\u0636\u0631\u0627\u0621"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0627\u0628 \u0627\u0644\u062e\u0636\u0631\u0627"
+    ],
     "name:eng_x_preferred":[
         "Bab el Khadra"
+    ],
+    "name:eng_x_variant":[
+        "Bab El Khadra"
     ],
     "name:fra_x_preferred":[
         "Bab El Khadra"
     ],
+    "name:gpe_x_preferred":[
+        "Bab El Khadra"
+    ],
+    "name:hau_x_preferred":[
+        "Bab El Khadra"
+    ],
     "name:nld_x_preferred":[
         "Bab el Khadra"
+    ],
+    "name:spa_x_preferred":[
+        "Bab El Khadra"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -75,7 +90,7 @@
         }
     ],
     "wof:id":421183851,
-    "wof:lastmodified":1566667319,
+    "wof:lastmodified":1690874859,
     "wof:name":"Bab El Khadra",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/421/185/613/421185613.geojson
+++ b/data/421/185/613/421185613.geojson
@@ -35,17 +35,26 @@
     "name:eng_x_preferred":[
         "Sbikha"
     ],
+    "name:fas_x_preferred":[
+        "\u0627\u0644\u0633\u0628\u06cc\u062e\u0647"
+    ],
     "name:fra_x_preferred":[
         "Sbikha"
     ],
     "name:nld_x_preferred":[
         "Sbikha"
     ],
+    "name:tur_x_preferred":[
+        "Sabiha"
+    ],
     "name:ukr_x_preferred":[
         "\u0421\u0431\u0456\u0445\u0430"
     ],
     "name:und_x_variant":[
         "Sbikra"
+    ],
+    "name:zul_x_preferred":[
+        "Sbikha"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -94,7 +103,7 @@
         }
     ],
     "wof:id":421185613,
-    "wof:lastmodified":1566667323,
+    "wof:lastmodified":1690874864,
     "wof:name":"As Subaykhah",
     "wof:parent_id":1108757397,
     "wof:placetype":"locality",

--- a/data/421/185/617/421185617.geojson
+++ b/data/421/185/617/421185617.geojson
@@ -35,6 +35,9 @@
     "name:eng_x_preferred":[
         "Fernana"
     ],
+    "name:fas_x_preferred":[
+        "\u0641\u0631\u0646\u0627\u0646\u0647"
+    ],
     "name:fra_x_preferred":[
         "Fernana"
     ],
@@ -44,11 +47,20 @@
     "name:nld_x_preferred":[
         "Fernana"
     ],
+    "name:spa_x_preferred":[
+        "Fernana"
+    ],
+    "name:tur_x_preferred":[
+        "Firnana"
+    ],
     "name:ukr_x_preferred":[
         "\u0424\u0435\u0440\u043d\u0430\u043d\u0430"
     ],
     "name:und_x_variant":[
         "Fernara"
+    ],
+    "name:zul_x_preferred":[
+        "Fernana"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -97,7 +109,7 @@
         }
     ],
     "wof:id":421185617,
-    "wof:lastmodified":1566667323,
+    "wof:lastmodified":1690874864,
     "wof:name":"Al Firnanah",
     "wof:parent_id":1108757361,
     "wof:placetype":"locality",

--- a/data/421/187/053/421187053.geojson
+++ b/data/421/187/053/421187053.geojson
@@ -50,6 +50,9 @@
     "name:ita_x_preferred":[
         "Zaghouan"
     ],
+    "name:jpn_x_preferred":[
+        "\u30b6\u30b0\u30a2\u30f3"
+    ],
     "name:kab_x_preferred":[
         "Za\u0263wan"
     ],
@@ -68,11 +71,20 @@
     "name:ron_x_preferred":[
         "Zaghouan"
     ],
+    "name:rus_x_preferred":[
+        "\u0417\u0430\u0433\u0432\u0430\u043d"
+    ],
     "name:sco_x_preferred":[
         "Zaghouan"
     ],
     "name:spa_x_preferred":[
         "Zaghouan"
+    ],
+    "name:swa_x_preferred":[
+        "Zaghouan"
+    ],
+    "name:tha_x_preferred":[
+        "\u0e0b\u0e31\u0e06\u0e27\u0e32\u0e19"
     ],
     "name:tur_x_preferred":[
         "Za\u011fvan"
@@ -85,6 +97,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5bb0\u683c\u842c"
+    ],
+    "name:zul_x_preferred":[
+        "Zaghouan"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Tunisia",
@@ -228,7 +243,7 @@
         }
     ],
     "wof:id":421187053,
-    "wof:lastmodified":1566667309,
+    "wof:lastmodified":1690874847,
     "wof:name":"Zaghwan",
     "wof:parent_id":1108757767,
     "wof:placetype":"locality",

--- a/data/421/188/189/421188189.geojson
+++ b/data/421/188/189/421188189.geojson
@@ -29,8 +29,14 @@
     "name:cat_x_variant":[
         "Beni Hassen"
     ],
+    "name:ceb_x_preferred":[
+        "Ban\u012b \u1e28ass\u0101n"
+    ],
     "name:deu_x_preferred":[
         "Ban\u012b Hass\u0101n"
+    ],
+    "name:deu_x_variant":[
+        "Beni Hassen"
     ],
     "name:eng_x_preferred":[
         "Beni Hassen"
@@ -68,11 +74,20 @@
     "name:swe_x_preferred":[
         "Beni Hassan-klanen"
     ],
+    "name:tur_x_preferred":[
+        "Beni Hasan"
+    ],
     "name:ukr_x_preferred":[
         "\u0411\u0435\u043d\u0456-\u0425\u0430\u0441\u0441\u0435\u043d"
     ],
     "name:und_x_variant":[
         "Beni Hassane"
+    ],
+    "name:urd_x_preferred":[
+        "\u0628\u0646\u06cc \u062d\u0633\u0627\u0646"
+    ],
+    "name:zul_x_preferred":[
+        "Beni Hassen"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -120,7 +135,7 @@
         }
     ],
     "wof:id":421188189,
-    "wof:lastmodified":1566667311,
+    "wof:lastmodified":1690874849,
     "wof:name":"Bani Hassan",
     "wof:parent_id":1108757535,
     "wof:placetype":"locality",

--- a/data/421/192/317/421192317.geojson
+++ b/data/421/192/317/421192317.geojson
@@ -35,7 +35,13 @@
     "name:eng_x_preferred":[
         "T\u00e9boulba"
     ],
+    "name:fas_x_preferred":[
+        "\u0637\u0628\u0644\u0628\u0647"
+    ],
     "name:fra_x_preferred":[
+        "T\u00e9boulba"
+    ],
+    "name:ita_x_preferred":[
         "T\u00e9boulba"
     ],
     "name:nld_x_preferred":[
@@ -47,8 +53,14 @@
     "name:ron_x_preferred":[
         "Teboulba"
     ],
+    "name:tur_x_preferred":[
+        "Tebulba"
+    ],
     "name:ukr_x_preferred":[
         "\u0422\u0435\u0431\u0443\u043b\u044c\u0431\u0430"
+    ],
+    "name:zul_x_preferred":[
+        "T\u00e9boulba"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -96,7 +108,7 @@
         }
     ],
     "wof:id":421192317,
-    "wof:lastmodified":1566667302,
+    "wof:lastmodified":1690874840,
     "wof:name":"Tabulbah",
     "wof:parent_id":1108757555,
     "wof:placetype":"locality",

--- a/data/421/192/785/421192785.geojson
+++ b/data/421/192/785/421192785.geojson
@@ -29,6 +29,12 @@
     "name:ceb_x_preferred":[
         "Qa\u015fr Hall\u0101l"
     ],
+    "name:dan_x_preferred":[
+        "Ksar Hellal"
+    ],
+    "name:deu_x_preferred":[
+        "Ksar Hellal"
+    ],
     "name:eng_x_preferred":[
         "Ksar Hellal"
     ],
@@ -38,7 +44,19 @@
     "name:fra_x_preferred":[
         "Ksar Hellal"
     ],
+    "name:gle_x_preferred":[
+        "Ksar Hellal"
+    ],
+    "name:ita_x_preferred":[
+        "Ksar Hellal"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30af\u30b5\u30fc\u30eb\u30fb\u30d8\u30e9\u30eb"
+    ],
     "name:nld_x_preferred":[
+        "Ksar Hellal"
+    ],
+    "name:por_x_preferred":[
         "Ksar Hellal"
     ],
     "name:ron_x_preferred":[
@@ -46,6 +64,12 @@
     ],
     "name:rus_x_preferred":[
         "\u041a\u0430\u0441\u0440-\u0425\u0438\u043b\u044f\u043b\u044c"
+    ],
+    "name:swe_x_preferred":[
+        "Ksar Hellal"
+    ],
+    "name:tur_x_preferred":[
+        "Kasr Hilal"
     ],
     "name:ukr_x_preferred":[
         "\u041a\u0441\u0430\u0440-\u0425\u0435\u043b\u043b\u044f\u043b\u044c"
@@ -55,6 +79,12 @@
     ],
     "name:urd_x_preferred":[
         "\u0642\u0635\u0631 \u06c1\u0644\u0627\u0644"
+    ],
+    "name:zho_x_preferred":[
+        "\u6d77\u62c9\u52d2\u5821"
+    ],
+    "name:zul_x_preferred":[
+        "Ksar Hellal"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -104,7 +134,7 @@
         }
     ],
     "wof:id":421192785,
-    "wof:lastmodified":1566667302,
+    "wof:lastmodified":1690874840,
     "wof:name":"Qasr Hallal",
     "wof:parent_id":1108757539,
     "wof:placetype":"locality",

--- a/data/421/193/199/421193199.geojson
+++ b/data/421/193/199/421193199.geojson
@@ -20,13 +20,22 @@
     "name:ara_x_preferred":[
         "\u0642\u0641\u0635\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0642\u0641\u0635\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u0642\u0641\u0635\u0647"
+    ],
+    "name:bel_x_preferred":[
+        "\u0413\u0430\u0444\u0441\u0430"
     ],
     "name:cat_x_preferred":[
         "Gafsa"
     ],
     "name:ceb_x_preferred":[
+        "Gafsa"
+    ],
+    "name:ces_x_preferred":[
         "Gafsa"
     ],
     "name:cym_x_preferred":[
@@ -86,6 +95,9 @@
     "name:nld_x_preferred":[
         "Gafsa"
     ],
+    "name:nob_x_preferred":[
+        "Gafsa"
+    ],
     "name:pol_x_preferred":[
         "Kafsa"
     ],
@@ -104,6 +116,12 @@
     "name:slv_x_preferred":[
         "Gafsa"
     ],
+    "name:spa_x_preferred":[
+        "Gafsa"
+    ],
+    "name:swa_x_preferred":[
+        "Gafsa"
+    ],
     "name:swe_x_preferred":[
         "Gafsa"
     ],
@@ -112,6 +130,9 @@
     ],
     "name:tha_x_preferred":[
         "\u0e01\u0e31\u0e1f\u0e0b\u0e32"
+    ],
+    "name:tha_x_variant":[
+        "\u0e01\u0e47\u0e2d\u0e1f\u0e40\u0e28\u0e32\u0e30\u0e2e\u0e4c"
     ],
     "name:tur_x_preferred":[
         "Kafsa"
@@ -124,6 +145,9 @@
     ],
     "name:zho_x_preferred":[
         "\u52a0\u592b\u85a9"
+    ],
+    "name:zul_x_preferred":[
+        "Gafsa"
     ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
@@ -172,7 +196,7 @@
         }
     ],
     "wof:id":421193199,
-    "wof:lastmodified":1566667304,
+    "wof:lastmodified":1690874842,
     "wof:name":"Qafsah",
     "wof:parent_id":1108757335,
     "wof:placetype":"locality",

--- a/data/421/193/237/421193237.geojson
+++ b/data/421/193/237/421193237.geojson
@@ -23,6 +23,9 @@
     "name:cat_x_preferred":[
         "Regueb"
     ],
+    "name:ceb_x_preferred":[
+        "Ar Riq\u0101b"
+    ],
     "name:cym_x_preferred":[
         "Regueb"
     ],
@@ -31,6 +34,9 @@
     ],
     "name:eng_x_preferred":[
         "Regueb"
+    ],
+    "name:fas_x_preferred":[
+        "\u0627\u0644\u0631\u0642\u0627\u0628"
     ],
     "name:fra_x_preferred":[
         "Regueb"
@@ -41,8 +47,14 @@
     "name:nld_x_preferred":[
         "Regueb"
     ],
+    "name:tur_x_preferred":[
+        "Rik\u00e2b"
+    ],
     "name:ukr_x_preferred":[
         "\u0420\u0435\u043a\u0435\u0431"
+    ],
+    "name:zul_x_preferred":[
+        "Regueb"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -90,7 +102,7 @@
         }
     ],
     "wof:id":421193237,
-    "wof:lastmodified":1566667304,
+    "wof:lastmodified":1690874842,
     "wof:name":"Ar Riqab",
     "wof:parent_id":1108757645,
     "wof:placetype":"locality",

--- a/data/421/194/225/421194225.geojson
+++ b/data/421/194/225/421194225.geojson
@@ -20,14 +20,23 @@
     "name:ara_x_preferred":[
         "\u0628\u0646\u0628\u0644\u0629"
     ],
+    "name:ast_x_preferred":[
+        "Bembla"
+    ],
     "name:cat_x_preferred":[
         "Bembla"
+    ],
+    "name:ceb_x_preferred":[
+        "Banbalah"
     ],
     "name:deu_x_preferred":[
         "Bembla"
     ],
     "name:eng_x_preferred":[
         "Bembla"
+    ],
+    "name:fas_x_preferred":[
+        "\u0628\u0646\u0628\u0644\u0647"
     ],
     "name:fra_x_preferred":[
         "Bembla"
@@ -41,8 +50,14 @@
     "name:ron_x_preferred":[
         "Bembla"
     ],
+    "name:tur_x_preferred":[
+        "Binuble"
+    ],
     "name:ukr_x_preferred":[
         "\u0411\u0435\u043d\u0431\u043b\u0430"
+    ],
+    "name:zul_x_preferred":[
+        "Bembla"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -90,7 +105,7 @@
         }
     ],
     "wof:id":421194225,
-    "wof:lastmodified":1566667303,
+    "wof:lastmodified":1690874842,
     "wof:name":"Banbalah",
     "wof:parent_id":1108757533,
     "wof:placetype":"locality",

--- a/data/421/194/595/421194595.geojson
+++ b/data/421/194/595/421194595.geojson
@@ -29,6 +29,9 @@
     "name:eng_x_preferred":[
         "Chorbane"
     ],
+    "name:fas_x_preferred":[
+        "\u0634\u0631\u0628\u0627\u0646"
+    ],
     "name:fra_x_preferred":[
         "Chorbane"
     ],
@@ -38,11 +41,17 @@
     "name:ron_x_preferred":[
         "Chorbane"
     ],
+    "name:tur_x_preferred":[
+        "\u015eurban"
+    ],
     "name:ukr_x_preferred":[
         "\u0428\u043e\u0440\u0431\u0430\u043d"
     ],
     "name:und_x_variant":[
         "Chourbane"
+    ],
+    "name:zul_x_preferred":[
+        "Chorbane"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -92,7 +101,7 @@
         }
     ],
     "wof:id":421194595,
-    "wof:lastmodified":1566667303,
+    "wof:lastmodified":1690874841,
     "wof:name":"Shurban",
     "wof:parent_id":1108757471,
     "wof:placetype":"locality",

--- a/data/421/194/801/421194801.geojson
+++ b/data/421/194/801/421194801.geojson
@@ -29,8 +29,14 @@
     "name:ceb_x_preferred":[
         "Degache"
     ],
+    "name:deu_x_preferred":[
+        "Degache"
+    ],
     "name:eng_x_preferred":[
         "Degache"
+    ],
+    "name:fas_x_preferred":[
+        "\u062f\u0642\u0627\u0634"
     ],
     "name:fra_x_preferred":[
         "Degache"
@@ -50,11 +56,17 @@
     "name:spa_x_preferred":[
         "Degache"
     ],
+    "name:tur_x_preferred":[
+        "Daka\u015f"
+    ],
     "name:ukr_x_preferred":[
         "\u0414\u0435\u043a\u0430\u0448"
     ],
     "name:und_x_variant":[
         "Deguach"
+    ],
+    "name:zul_x_preferred":[
+        "Degache"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -104,7 +116,7 @@
         }
     ],
     "wof:id":421194801,
-    "wof:lastmodified":1566667303,
+    "wof:lastmodified":1690874842,
     "wof:name":"Degache",
     "wof:parent_id":1108757735,
     "wof:placetype":"locality",

--- a/data/421/195/109/421195109.geojson
+++ b/data/421/195/109/421195109.geojson
@@ -47,6 +47,9 @@
     "name:ita_x_preferred":[
         "Adjim"
     ],
+    "name:jpn_x_preferred":[
+        "\u30a2\u30b8\u30e0"
+    ],
     "name:nld_x_preferred":[
         "Ajim"
     ],
@@ -56,14 +59,23 @@
     "name:por_x_preferred":[
         "Ajim"
     ],
+    "name:rus_x_preferred":[
+        "\u0410\u0434\u0436\u0438\u043c"
+    ],
     "name:sco_x_preferred":[
         "Ajim"
+    ],
+    "name:tur_x_preferred":[
+        "Acim"
     ],
     "name:ukr_x_preferred":[
         "\u0410\u0434\u0436\u0456\u043c"
     ],
     "name:und_x_variant":[
         "Humt-Ajim"
+    ],
+    "name:zul_x_preferred":[
+        "Ajim"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -112,7 +124,7 @@
         }
     ],
     "wof:id":421195109,
-    "wof:lastmodified":1566667303,
+    "wof:lastmodified":1690874841,
     "wof:name":"Ajim",
     "wof:parent_id":1108757515,
     "wof:placetype":"locality",

--- a/data/421/195/703/421195703.geojson
+++ b/data/421/195/703/421195703.geojson
@@ -41,11 +41,20 @@
     "name:arg_x_preferred":[
         "T\u00faniz"
     ],
+    "name:arq_x_preferred":[
+        "\u062a\u0648\u0646\u0633"
+    ],
+    "name:ary_x_preferred":[
+        "\u062a\u0648\u0646\u0633"
+    ],
     "name:arz_x_preferred":[
         "\u062a\u0648\u0646\u0633"
     ],
     "name:ast_x_preferred":[
         "T\u00fanez"
+    ],
+    "name:avk_x_preferred":[
+        "Tunus"
     ],
     "name:azb_x_preferred":[
         "\u062a\u0648\u0646\u0633"
@@ -55,6 +64,9 @@
     ],
     "name:bak_x_preferred":[
         "\u0422\u0443\u043d\u0438\u0441"
+    ],
+    "name:ban_x_preferred":[
+        "Tunis"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0422\u0443\u043d\u0456\u0441"
@@ -158,6 +170,9 @@
     "name:glg_x_preferred":[
         "Tunes"
     ],
+    "name:grc_x_preferred":[
+        "\u03a4\u03cd\u03bd\u03b7\u03c2"
+    ],
     "name:gsw_x_preferred":[
         "Tunis"
     ],
@@ -206,6 +221,9 @@
     "name:ile_x_preferred":[
         "Tunis"
     ],
+    "name:ina_x_preferred":[
+        "Tunis"
+    ],
     "name:ind_x_preferred":[
         "Tunis"
     ],
@@ -229,6 +247,9 @@
     ],
     "name:kat_x_preferred":[
         "\u10e2\u10e3\u10dc\u10d8\u10e1\u10d8"
+    ],
+    "name:kaz_x_preferred":[
+        "\u0422\u0443\u043d\u0438\u0441"
     ],
     "name:kbp_x_preferred":[
         "Tunisi"
@@ -269,11 +290,17 @@
     "name:mar_x_preferred":[
         "\u091f\u094d\u092f\u0941\u0928\u093f\u0938"
     ],
+    "name:mdf_x_preferred":[
+        "\u0422\u0443\u043d\u0438\u0441"
+    ],
     "name:mkd_x_preferred":[
         "\u0422\u0443\u043d\u0438\u0441"
     ],
     "name:mlg_x_preferred":[
         "Tunis"
+    ],
+    "name:mlt_x_preferred":[
+        "Tune\u017c"
     ],
     "name:mon_x_preferred":[
         "\u0422\u0443\u043d\u0438\u0441 \u0445\u043e\u0442"
@@ -283,6 +310,12 @@
     ],
     "name:msa_x_preferred":[
         "Tunis"
+    ],
+    "name:myv_x_preferred":[
+        "\u0422\u0443\u043d\u0438\u0441"
+    ],
+    "name:mzn_x_preferred":[
+        "\u062a\u0648\u0646\u0633"
     ],
     "name:nan_x_preferred":[
         "Tunis"
@@ -335,6 +368,9 @@
     "name:pus_x_preferred":[
         "\u062a\u0648\u0646\u0633 \u069a\u0627\u0631"
     ],
+    "name:pwn_x_preferred":[
+        "tunis"
+    ],
     "name:que_x_preferred":[
         "Tunis"
     ],
@@ -346,6 +382,9 @@
     ],
     "name:sah_x_preferred":[
         "\u0422\u0443\u043d\u0438\u0441"
+    ],
+    "name:sat_x_preferred":[
+        "\u1c74\u1c69\u1c71\u1c64\u1c65"
     ],
     "name:scn_x_preferred":[
         "T\u00f9nisi"
@@ -360,6 +399,15 @@
         "Tunis"
     ],
     "name:slv_x_preferred":[
+        "Tunis"
+    ],
+    "name:sme_x_preferred":[
+        "Tunis"
+    ],
+    "name:smn_x_preferred":[
+        "Tunis"
+    ],
+    "name:sms_x_preferred":[
         "Tunis"
     ],
     "name:sna_x_preferred":[
@@ -377,6 +425,9 @@
     "name:sqi_x_preferred":[
         "Tunis"
     ],
+    "name:srd_x_preferred":[
+        "T\u00f9nisi"
+    ],
     "name:srp_x_preferred":[
         "\u0422\u0443\u043d\u0438\u0441"
     ],
@@ -391,6 +442,9 @@
     ],
     "name:tam_x_preferred":[
         "\u0ba4\u0bc2\u0ba9\u0bbf\u0bb8\u0bcd"
+    ],
+    "name:tat_x_preferred":[
+        "\u0422\u0443\u043d\u0438\u0441"
     ],
     "name:tel_x_preferred":[
         "\u0c1f\u0c4d\u0c2f\u0c42\u0c28\u0c3f\u0c38\u0c4d"
@@ -440,6 +494,9 @@
     "name:vie_x_preferred":[
         "Tunis"
     ],
+    "name:vol_x_preferred":[
+        "Tunis"
+    ],
     "name:war_x_preferred":[
         "Tunis"
     ],
@@ -469,6 +526,9 @@
     ],
     "name:zho_x_variant":[
         "\u7a81\u5c3c\u65af\u5e02"
+    ],
+    "name:zul_x_preferred":[
+        "Tunis"
     ],
     "ne:ADM0CAP":1.0,
     "ne:ADM0NAME":"Tunisia",
@@ -622,7 +682,7 @@
         }
     ],
     "wof:id":421195703,
-    "wof:lastmodified":1636495672,
+    "wof:lastmodified":1690874841,
     "wof:name":"Tunis",
     "wof:parent_id":85679123,
     "wof:placetype":"locality",

--- a/data/421/195/929/421195929.geojson
+++ b/data/421/195/929/421195929.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u062d\u0645\u0627\u0645\u0627\u062a"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u062d\u0645\u0627\u0645\u0627\u062a"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u0644\u062d\u0645\u0627\u0645\u0627\u062a"
     ],
@@ -50,6 +53,9 @@
     "name:deu_x_preferred":[
         "Hammamet"
     ],
+    "name:ell_x_preferred":[
+        "\u03a7\u03b1\u03bc\u03b1\u03bc\u03ad\u03c4"
+    ],
     "name:eng_x_preferred":[
         "Hammamet"
     ],
@@ -74,6 +80,9 @@
     "name:hun_x_preferred":[
         "Hammamet"
     ],
+    "name:hun_x_variant":[
+        "Hamm\u00e1met"
+    ],
     "name:ind_x_preferred":[
         "Al-Hammamat"
     ],
@@ -88,6 +97,9 @@
     ],
     "name:lit_x_preferred":[
         "Hamametas"
+    ],
+    "name:mdf_x_preferred":[
+        "\u0413\u0430\u043c\u043c\u0430\u043c\u044d\u0442"
     ],
     "name:nld_x_preferred":[
         "Hammamet"
@@ -125,6 +137,9 @@
     "name:ukr_x_preferred":[
         "\u0425\u0430\u043c\u043c\u0430\u043c\u0435\u0442"
     ],
+    "name:ukr_x_variant":[
+        "\u0413\u0430\u043c\u043c\u0430\u043c\u0435\u0442"
+    ],
     "name:urd_x_preferred":[
         "\u062d\u0645\u0627\u0645\u0627\u062a\u060c \u062a\u06cc\u0648\u0646\u0633"
     ],
@@ -133,6 +148,9 @@
     ],
     "name:zho_x_preferred":[
         "\u54c8\u9a6c\u9a6c\u7279"
+    ],
+    "name:zul_x_preferred":[
+        "Hammamet"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -184,7 +202,7 @@
         }
     ],
     "wof:id":421195929,
-    "wof:lastmodified":1566667303,
+    "wof:lastmodified":1690874841,
     "wof:name":"Al Hammamat",
     "wof:parent_id":1108757569,
     "wof:placetype":"locality",

--- a/data/421/195/963/421195963.geojson
+++ b/data/421/195/963/421195963.geojson
@@ -32,8 +32,17 @@
     "name:cym_x_preferred":[
         "Mahr\u00e8s"
     ],
+    "name:deu_x_preferred":[
+        "Mahres"
+    ],
     "name:eng_x_preferred":[
         "Mahares"
+    ],
+    "name:eng_x_variant":[
+        "Mahres"
+    ],
+    "name:fas_x_preferred":[
+        "\u0627\u0644\u0645\u062d\u0631\u0633"
     ],
     "name:fra_x_preferred":[
         "Mahr\u00e8s"
@@ -47,11 +56,23 @@
     "name:nld_x_preferred":[
         "Mahares"
     ],
+    "name:rus_x_preferred":[
+        "\u041c\u0430\u0445\u0430\u0440\u0435\u0441"
+    ],
+    "name:tur_x_preferred":[
+        "Mahris"
+    ],
     "name:ukr_x_preferred":[
         "\u041c\u0430\u0445\u0440\u0435\u0441"
     ],
     "name:und_x_variant":[
         "Al Ma\u1e29ras"
+    ],
+    "name:zho_x_preferred":[
+        "\u9a6c\u54c8\u96f7\u65af"
+    ],
+    "name:zul_x_preferred":[
+        "Mahres"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -99,7 +120,7 @@
         }
     ],
     "wof:id":421195963,
-    "wof:lastmodified":1566667303,
+    "wof:lastmodified":1690874840,
     "wof:name":"Al Mahras",
     "wof:parent_id":1108757611,
     "wof:placetype":"locality",

--- a/data/421/196/807/421196807.geojson
+++ b/data/421/196/807/421196807.geojson
@@ -20,20 +20,32 @@
     "name:ara_x_preferred":[
         "\u0632\u0627\u0648\u064a\u0629 \u0627\u0644\u062c\u062f\u064a\u062f\u064a"
     ],
+    "name:cat_x_preferred":[
+        "Zaouiet Djedidi"
+    ],
     "name:ceb_x_preferred":[
         "Z\u0101wiyat al Jad\u012bd\u012b"
     ],
     "name:eng_x_preferred":[
         "Zaouiet Djedidi"
     ],
+    "name:fas_x_preferred":[
+        "\u0632\u0627\u0648\u06cc\u0647 \u0627\u0644\u062c\u062f\u06cc\u062f\u06cc"
+    ],
     "name:fra_x_preferred":[
         "Zaouiet Djedidi"
+    ],
+    "name:tur_x_preferred":[
+        "Zaviyet\u00fc'l-Cedidi"
     ],
     "name:ukr_x_preferred":[
         "\u0417\u0430\u0443\u0432'\u0454\u0442-\u0414\u0436\u0435\u0434\u0456\u0434\u0456"
     ],
     "name:und_x_variant":[
         "Sidi Djedidi"
+    ],
+    "name:zul_x_preferred":[
+        "Zaouiet Djedidi"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -82,7 +94,7 @@
         }
     ],
     "wof:id":421196807,
-    "wof:lastmodified":1566667313,
+    "wof:lastmodified":1690874851,
     "wof:name":"Zawiyat al Jadidi",
     "wof:parent_id":1108757561,
     "wof:placetype":"locality",

--- a/data/421/197/967/421197967.geojson
+++ b/data/421/197/967/421197967.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0635\u0641\u0627\u0642\u0633"
     ],
+    "name:arz_x_preferred":[
+        "\u0635\u0641\u0627\u0642\u0633"
+    ],
     "name:azb_x_preferred":[
         "\u0635\u0641\u0627\u0642\u0633"
     ],
@@ -107,6 +110,9 @@
     "name:ido_x_preferred":[
         "Sfax"
     ],
+    "name:ile_x_preferred":[
+        "Sfax"
+    ],
     "name:ind_x_preferred":[
         "Sfax"
     ],
@@ -131,6 +137,9 @@
     "name:lat_x_preferred":[
         "Thaenae"
     ],
+    "name:lat_x_variant":[
+        "Sfax"
+    ],
     "name:lav_x_preferred":[
         "Sfaksa"
     ],
@@ -142,6 +151,9 @@
     ],
     "name:mar_x_preferred":[
         "\u0938\u094d\u092b\u093e\u0915\u094d\u0938"
+    ],
+    "name:mlt_x_preferred":[
+        "Sfax"
     ],
     "name:msa_x_preferred":[
         "Sfax"
@@ -157,6 +169,9 @@
     ],
     "name:oci_x_preferred":[
         "Sfax"
+    ],
+    "name:oss_x_preferred":[
+        "\u0421\u0444\u0430\u043a\u0441"
     ],
     "name:pol_x_preferred":[
         "Safakis"
@@ -182,6 +197,9 @@
     "name:sin_x_preferred":[
         "\u0d91\u0dc3\u0dca\u0dc6\u0d9a\u0dca\u0dc3\u0dca"
     ],
+    "name:slk_x_preferred":[
+        "Sfax"
+    ],
     "name:slv_x_preferred":[
         "Sfax"
     ],
@@ -190,6 +208,9 @@
     ],
     "name:srp_x_preferred":[
         "\u0421\u0444\u0430\u043a\u0441"
+    ],
+    "name:swa_x_preferred":[
+        "Sfax"
     ],
     "name:swe_x_preferred":[
         "Sfax"
@@ -215,14 +236,23 @@
     "name:urd_x_preferred":[
         "\u0635\u0641\u0627\u0642\u0633"
     ],
+    "name:uzb_x_preferred":[
+        "Sfaks"
+    ],
     "name:vie_x_preferred":[
         "Sfax"
     ],
     "name:war_x_preferred":[
         "Sfax"
     ],
+    "name:wuu_x_preferred":[
+        "\u65af\u6cd5\u514b\u65af"
+    ],
     "name:zho_x_preferred":[
         "\u65af\u6cd5\u514b\u65af"
+    ],
+    "name:zul_x_preferred":[
+        "Sfax"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Tunisia",
@@ -363,7 +393,7 @@
         }
     ],
     "wof:id":421197967,
-    "wof:lastmodified":1566667313,
+    "wof:lastmodified":1690874851,
     "wof:name":"Safaqis",
     "wof:parent_id":1108757621,
     "wof:placetype":"locality",

--- a/data/421/197/969/421197969.geojson
+++ b/data/421/197/969/421197969.geojson
@@ -24,11 +24,20 @@
         "\u0648\u0644\u0627\u064a\u0629 \u0642\u0627\u0628\u0633",
         "\u06a4\u0627\u0628\u0633"
     ],
+    "name:arz_x_preferred":[
+        "\u0642\u0627\u0628\u0633"
+    ],
     "name:azb_x_preferred":[
         "\u0642\u0627\u0628\u0633"
     ],
+    "name:aze_x_preferred":[
+        "Qabes"
+    ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0413\u0430\u0431\u0435\u0441"
+    ],
+    "name:bel_x_variant":[
+        "\u0413\u0430\u0431\u0435\u0441"
     ],
     "name:bre_x_preferred":[
         "Gab\u00e8s"
@@ -39,8 +48,14 @@
     "name:cat_x_preferred":[
         "Gab\u00e8s"
     ],
+    "name:ceb_x_preferred":[
+        "Gab\u00e8s"
+    ],
     "name:ces_x_preferred":[
         "Gab\u00e8s"
+    ],
+    "name:ces_x_variant":[
+        "G\u00e1bes"
     ],
     "name:cym_x_preferred":[
         "Gab\u00e8s"
@@ -78,6 +93,9 @@
     "name:fra_x_preferred":[
         "Gab\u00e8s"
     ],
+    "name:gle_x_preferred":[
+        "Gab\u00e8s"
+    ],
     "name:hbs_x_preferred":[
         "Gabes"
     ],
@@ -86,6 +104,9 @@
     ],
     "name:hun_x_preferred":[
         "K\u00e1besz"
+    ],
+    "name:hye_x_preferred":[
+        "\u0533\u0561\u0562\u0565\u057d"
     ],
     "name:ita_x_preferred":[
         "Gab\u00e8s"
@@ -109,6 +130,9 @@
         "Gab\u00e8s"
     ],
     "name:nld_x_preferred":[
+        "Gab\u00e8s"
+    ],
+    "name:nob_x_preferred":[
         "Gab\u00e8s"
     ],
     "name:pol_x_preferred":[
@@ -144,6 +168,9 @@
     "name:tha_x_preferred":[
         "\u0e01\u0e32\u0e41\u0e1a\u0e47\u0e2a"
     ],
+    "name:tha_x_variant":[
+        "\u0e01\u0e2d\u0e1a\u0e34\u0e2a"
+    ],
     "name:tur_x_preferred":[
         "Gabes"
     ],
@@ -159,8 +186,14 @@
     "name:war_x_preferred":[
         "Gab\u00e8s"
     ],
+    "name:yid_x_preferred":[
+        "\u05d2\u05d0\u05d1\u05e2\u05e1"
+    ],
     "name:zho_x_preferred":[
         "\u52a0\u8c9d\u65af"
+    ],
+    "name:zul_x_preferred":[
+        "Gab\u00e8s"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Tunisia",
@@ -300,7 +333,7 @@
         }
     ],
     "wof:id":421197969,
-    "wof:lastmodified":1566667314,
+    "wof:lastmodified":1690874852,
     "wof:name":"Qabis",
     "wof:parent_id":1108757309,
     "wof:placetype":"locality",

--- a/data/421/197/971/421197971.geojson
+++ b/data/421/197/971/421197971.geojson
@@ -26,8 +26,14 @@
     "name:ceb_x_preferred":[
         "El Fahs"
     ],
+    "name:ces_x_preferred":[
+        "El Fahs"
+    ],
     "name:eng_x_preferred":[
         "El Fahs"
+    ],
+    "name:fas_x_preferred":[
+        "\u0627\u0644\u0641\u062d\u0635"
     ],
     "name:fra_x_preferred":[
         "El Fahs"
@@ -47,11 +53,17 @@
     "name:sco_x_preferred":[
         "El Fahs"
     ],
+    "name:tur_x_preferred":[
+        "El-Fahs"
+    ],
     "name:ukr_x_preferred":[
         "\u0415\u043b\u044c-\u0424\u0430\u0445\u0441"
     ],
     "name:und_x_variant":[
         "Pont-du-Fahs"
+    ],
+    "name:zul_x_preferred":[
+        "El Fahs"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -100,7 +112,7 @@
         }
     ],
     "wof:id":421197971,
-    "wof:lastmodified":1566667313,
+    "wof:lastmodified":1690874851,
     "wof:name":"Qantarat al Fahs",
     "wof:parent_id":1108757759,
     "wof:placetype":"locality",

--- a/data/421/197/973/421197973.geojson
+++ b/data/421/197/973/421197973.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0646\u0641\u0637\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0646\u0641\u0637\u0647"
+    ],
     "name:cat_x_preferred":[
         "Nefta"
     ],
@@ -29,8 +32,14 @@
     "name:eng_x_preferred":[
         "Nafta"
     ],
+    "name:fas_x_preferred":[
+        "\u0646\u0641\u0637\u0647"
+    ],
     "name:fra_x_preferred":[
         "Nefta"
+    ],
+    "name:heb_x_preferred":[
+        "\u05e0\u05e4\u05ea\u05d0"
     ],
     "name:kaz_x_preferred":[
         "\u041d\u0435\u0444\u0442\u0430 \u0448\u04b1\u0440\u0430\u0442\u044b"
@@ -53,11 +62,20 @@
     "name:sco_x_preferred":[
         "Nefta"
     ],
+    "name:tur_x_preferred":[
+        "Nefta"
+    ],
     "name:ukr_x_preferred":[
         "\u041d\u0435\u0444\u0442\u0430"
     ],
     "name:und_x_variant":[
         "Aggarset Nepte"
+    ],
+    "name:urd_x_preferred":[
+        "\u0646\u0641\u0637\u06c1"
+    ],
+    "name:zul_x_preferred":[
+        "Nefta"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -107,7 +125,7 @@
         }
     ],
     "wof:id":421197973,
-    "wof:lastmodified":1566667314,
+    "wof:lastmodified":1690874852,
     "wof:name":"Naftah",
     "wof:parent_id":1108757739,
     "wof:placetype":"locality",

--- a/data/421/199/067/421199067.geojson
+++ b/data/421/199/067/421199067.geojson
@@ -32,17 +32,26 @@
     "name:eng_x_preferred":[
         "Jilma"
     ],
+    "name:fas_x_preferred":[
+        "\u062c\u0644\u0645\u0629"
+    ],
     "name:fra_x_preferred":[
         "Jilma"
     ],
     "name:nld_x_preferred":[
         "Jilma"
     ],
+    "name:tur_x_preferred":[
+        "Cilme"
+    ],
     "name:ukr_x_preferred":[
         "\u0414\u0436\u0456\u043b\u043c\u0430"
     ],
     "name:und_x_variant":[
         "Djilma"
+    ],
+    "name:zul_x_preferred":[
+        "Jilma"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -92,7 +101,7 @@
         }
     ],
     "wof:id":421199067,
-    "wof:lastmodified":1566667315,
+    "wof:lastmodified":1690874854,
     "wof:name":"Jilmah",
     "wof:parent_id":1108757633,
     "wof:placetype":"locality",

--- a/data/421/199/069/421199069.geojson
+++ b/data/421/199/069/421199069.geojson
@@ -20,11 +20,17 @@
     "name:ara_x_preferred":[
         "\u062c\u0645\u0646\u0629"
     ],
+    "name:cat_x_preferred":[
+        "Jemna"
+    ],
     "name:ceb_x_preferred":[
         "Jemna"
     ],
     "name:eng_x_preferred":[
         "Djemna"
+    ],
+    "name:fas_x_preferred":[
+        "\u062c\u0645\u0646\u0647"
     ],
     "name:fra_x_preferred":[
         "Jemna"
@@ -38,11 +44,17 @@
     "name:sco_x_preferred":[
         "Djemna"
     ],
+    "name:tur_x_preferred":[
+        "Cemna"
+    ],
     "name:ukr_x_preferred":[
         "\u0414\u0436\u0435\u043c\u043d\u0430"
     ],
     "name:und_x_variant":[
         "Djemma"
+    ],
+    "name:zul_x_preferred":[
+        "Djemna"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -91,7 +103,7 @@
         }
     ],
     "wof:id":421199069,
-    "wof:lastmodified":1566667315,
+    "wof:lastmodified":1690874854,
     "wof:name":"Jamnah",
     "wof:parent_id":1108757437,
     "wof:placetype":"locality",

--- a/data/421/199/071/421199071.geojson
+++ b/data/421/199/071/421199071.geojson
@@ -29,8 +29,14 @@
     "name:cym_x_preferred":[
         "Jebiniana"
     ],
+    "name:deu_x_preferred":[
+        "Jebiniana"
+    ],
     "name:eng_x_preferred":[
         "Jebiniana"
+    ],
+    "name:fas_x_preferred":[
+        "\u062c\u0628\u0646\u06cc\u0627\u0646\u0647"
     ],
     "name:fra_x_preferred":[
         "Jebiniana"
@@ -38,11 +44,23 @@
     "name:nld_x_preferred":[
         "Jebiniana"
     ],
+    "name:rus_x_preferred":[
+        "\u0414\u0436\u0435\u0431\u0438\u043d\u044c\u044f\u043d\u0430"
+    ],
+    "name:swa_x_preferred":[
+        "Jebiniana"
+    ],
+    "name:tur_x_preferred":[
+        "Cabniyane"
+    ],
     "name:ukr_x_preferred":[
         "\u0414\u0436\u0435\u0431\u0456\u043d\u044c\u044f\u043d\u0430"
     ],
     "name:und_x_variant":[
         "Djebaniana"
+    ],
+    "name:zul_x_preferred":[
+        "Jebiniana"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -92,7 +110,7 @@
         }
     ],
     "wof:id":421199071,
-    "wof:lastmodified":1566667314,
+    "wof:lastmodified":1690874852,
     "wof:name":"Jabinyanah",
     "wof:parent_id":1108757599,
     "wof:placetype":"locality",

--- a/data/421/199/075/421199075.geojson
+++ b/data/421/199/075/421199075.geojson
@@ -26,8 +26,14 @@
     "name:ceb_x_preferred":[
         "Ksour Essaf"
     ],
+    "name:deu_x_preferred":[
+        "Ksour Essef"
+    ],
     "name:eng_x_preferred":[
         "Ksour Essef"
+    ],
+    "name:fas_x_preferred":[
+        "\u0642\u0635\u0648\u0631 \u0627\u0644\u0633\u0627\u0641"
     ],
     "name:fra_x_preferred":[
         "Ksour Essef"
@@ -41,11 +47,23 @@
     "name:spa_x_preferred":[
         "Ksour Essef"
     ],
+    "name:swe_x_preferred":[
+        "Tunis kommun"
+    ],
+    "name:tur_x_preferred":[
+        "Kusur\u00fc's-Sef"
+    ],
     "name:ukr_x_preferred":[
         "\u041a\u0441\u0443\u0440-\u0435\u0441-\u0421\u0435\u0444"
     ],
     "name:und_x_variant":[
         "Qsour Essaf"
+    ],
+    "name:urd_x_preferred":[
+        "\u0642\u0635\u0648\u0631 \u0627\u0644\u0633\u0627\u0641"
+    ],
+    "name:zul_x_preferred":[
+        "Ksour Essef"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -94,7 +112,7 @@
         }
     ],
     "wof:id":421199075,
-    "wof:lastmodified":1566667315,
+    "wof:lastmodified":1690874853,
     "wof:name":"Qusur as Saf",
     "wof:parent_id":1108757479,
     "wof:placetype":"locality",

--- a/data/421/199/077/421199077.geojson
+++ b/data/421/199/077/421199077.geojson
@@ -26,8 +26,14 @@
     "name:ceb_x_preferred":[
         "Qu\u015faybat al Mady\u016bn\u012b"
     ],
+    "name:deu_x_preferred":[
+        "Ksibet El Mediouni"
+    ],
     "name:eng_x_preferred":[
         "Ksibet El Mediouni"
+    ],
+    "name:fas_x_preferred":[
+        "\u0642\u0635\u06cc\u0628\u0647 \u0627\u0644\u0645\u062f\u06cc\u0648\u0646\u06cc"
     ],
     "name:fra_x_preferred":[
         "Ksibet el-M\u00e9diouni"
@@ -38,11 +44,17 @@
     "name:ron_x_preferred":[
         "Ksibet El Mediouni"
     ],
+    "name:tur_x_preferred":[
+        "Kusaybet\u00fc'l-Medyuni"
+    ],
     "name:ukr_x_preferred":[
         "\u041a\u0441\u0456\u0431\u0435\u0442-\u0435\u043b\u044c-\u041c\u0435\u0434\u0456\u0443\u043d\u0456"
     ],
     "name:und_x_variant":[
         "Sieba"
+    ],
+    "name:zul_x_preferred":[
+        "Ksibet El Mediouni"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -91,7 +103,7 @@
         }
     ],
     "wof:id":421199077,
-    "wof:lastmodified":1566667314,
+    "wof:lastmodified":1690874852,
     "wof:name":"Qusaybat al Madyuni",
     "wof:parent_id":1108757541,
     "wof:placetype":"locality",

--- a/data/421/199/079/421199079.geojson
+++ b/data/421/199/079/421199079.geojson
@@ -32,11 +32,20 @@
     "name:eng_x_preferred":[
         "Oued Melliz"
     ],
+    "name:fas_x_preferred":[
+        "\u0648\u0627\u062f\u06cc \u0645\u0644\u06cc\u0632"
+    ],
     "name:fra_x_preferred":[
         "Oued Meliz"
     ],
+    "name:tur_x_preferred":[
+        "Vadi Meliz"
+    ],
     "name:ukr_x_preferred":[
         "\u0423\u0435\u0434\u0456-\u041c\u0435\u043b\u0456\u0437"
+    ],
+    "name:zul_x_preferred":[
+        "Oued Melliz"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -85,7 +94,7 @@
         }
     ],
     "wof:id":421199079,
-    "wof:lastmodified":1566667314,
+    "wof:lastmodified":1690874852,
     "wof:name":"Wadi Maliz",
     "wof:parent_id":1108757371,
     "wof:placetype":"locality",

--- a/data/421/199/635/421199635.geojson
+++ b/data/421/199/635/421199635.geojson
@@ -44,6 +44,9 @@
     "name:eus_x_preferred":[
         "Matmata"
     ],
+    "name:fas_x_preferred":[
+        "\u0645\u0637\u0645\u0627\u0637\u0647"
+    ],
     "name:fin_x_preferred":[
         "Matmata"
     ],
@@ -95,6 +98,15 @@
     "name:und_x_variant":[
         "Kalaa Matmata"
     ],
+    "name:urd_x_preferred":[
+        "\u0645\u062a\u0645\u0627\u062a\u0627"
+    ],
+    "name:zho_x_preferred":[
+        "\u9a6c\u7279\u9a6c\u5854\u9ad8\u539f"
+    ],
+    "name:zul_x_preferred":[
+        "Matmata"
+    ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
     "qs:gn_id":2463810,
@@ -143,7 +155,7 @@
         }
     ],
     "wof:id":421199635,
-    "wof:lastmodified":1566667314,
+    "wof:lastmodified":1690874853,
     "wof:name":"Matmatah",
     "wof:parent_id":1108757321,
     "wof:placetype":"locality",

--- a/data/421/199/771/421199771.geojson
+++ b/data/421/199/771/421199771.geojson
@@ -38,6 +38,9 @@
     "name:deu_x_preferred":[
         "El Djem"
     ],
+    "name:ell_x_preferred":[
+        "\u0395\u03bb \u03a4\u03b6\u03b5\u03bc"
+    ],
     "name:eng_x_preferred":[
         "El Jem"
     ],
@@ -46,6 +49,9 @@
     ],
     "name:eus_x_preferred":[
         "El Djem"
+    ],
+    "name:fas_x_preferred":[
+        "\u0627\u0644\u062c\u0645"
     ],
     "name:fin_x_preferred":[
         "El Jem"
@@ -58,6 +64,9 @@
     ],
     "name:hun_x_preferred":[
         "El Djem"
+    ],
+    "name:hun_x_variant":[
+        "el-Dzsem"
     ],
     "name:hye_x_preferred":[
         "\u0537\u056c \u054b\u0565\u0574"
@@ -128,6 +137,9 @@
     "name:zho_x_preferred":[
         "\u5091\u59c6"
     ],
+    "name:zul_x_preferred":[
+        "El Djem"
+    ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
     "qs:gn_id":2473654,
@@ -175,7 +187,7 @@
         }
     ],
     "wof:id":421199771,
-    "wof:lastmodified":1566667315,
+    "wof:lastmodified":1690874853,
     "wof:name":"Al Jamm",
     "wof:parent_id":1108757473,
     "wof:placetype":"locality",

--- a/data/421/199/777/421199777.geojson
+++ b/data/421/199/777/421199777.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0643\u0627\u0641"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0643\u0627\u0641"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u0644\u06a9\u0627\u0641"
     ],
@@ -80,6 +83,9 @@
     "name:nld_x_preferred":[
         "El Kef"
     ],
+    "name:nob_x_preferred":[
+        "El Kef"
+    ],
     "name:oci_x_preferred":[
         "El Kef"
     ],
@@ -104,6 +110,12 @@
     "name:spa_x_preferred":[
         "Al-K\u0101f"
     ],
+    "name:swe_x_preferred":[
+        "El Kef"
+    ],
+    "name:tha_x_preferred":[
+        "\u0e2d\u0e31\u0e25\u0e01\u0e32\u0e1f"
+    ],
     "name:tur_x_preferred":[
         "El K\u00e2f"
     ],
@@ -118,6 +130,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5361\u592b"
+    ],
+    "name:zul_x_preferred":[
+        "El Kef"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Tunisia",
@@ -261,7 +276,7 @@
         }
     ],
     "wof:id":421199777,
-    "wof:lastmodified":1566667315,
+    "wof:lastmodified":1690874853,
     "wof:name":"Al Kaf",
     "wof:parent_id":1108757455,
     "wof:placetype":"locality",

--- a/data/421/200/269/421200269.geojson
+++ b/data/421/200/269/421200269.geojson
@@ -29,6 +29,9 @@
     "name:ceb_x_preferred":[
         "Al Baq\u0101li\u0163ah"
     ],
+    "name:deu_x_preferred":[
+        "Bekalta"
+    ],
     "name:eng_x_preferred":[
         "Bekalta"
     ],
@@ -50,11 +53,17 @@
     "name:ron_x_preferred":[
         "Bekalta"
     ],
+    "name:tur_x_preferred":[
+        "Bikalite"
+    ],
     "name:ukr_x_preferred":[
         "\u0411\u0435\u043a\u0430\u043b\u044c\u0442\u0430"
     ],
     "name:und_x_variant":[
         "Mkalta"
+    ],
+    "name:zul_x_preferred":[
+        "Bekalta"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -103,7 +112,7 @@
         }
     ],
     "wof:id":421200269,
-    "wof:lastmodified":1566667316,
+    "wof:lastmodified":1690874855,
     "wof:name":"Al Baqalitah",
     "wof:parent_id":1108757531,
     "wof:placetype":"locality",

--- a/data/421/200/283/421200283.geojson
+++ b/data/421/200/283/421200283.geojson
@@ -35,6 +35,9 @@
     "name:eng_x_variant":[
         "Beni Khalled"
     ],
+    "name:fas_x_preferred":[
+        "\u0628\u0646\u06cc \u062e\u0644\u0627\u062f"
+    ],
     "name:fra_x_preferred":[
         "B\u00e9ni Khalled"
     ],
@@ -47,8 +50,14 @@
     "name:ron_x_preferred":[
         "Beni Khaled"
     ],
+    "name:tur_x_preferred":[
+        "Beni Halid"
+    ],
     "name:ukr_x_preferred":[
         "\u0411\u0435\u043d\u0456-\u0425\u0430\u043b\u0435\u0434"
+    ],
+    "name:zul_x_preferred":[
+        "B\u00e9ni Khalled"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -98,7 +107,7 @@
         }
     ],
     "wof:id":421200283,
-    "wof:lastmodified":1566667316,
+    "wof:lastmodified":1690874855,
     "wof:name":"Bani Khallad",
     "wof:parent_id":1108757561,
     "wof:placetype":"locality",

--- a/data/421/200/285/421200285.geojson
+++ b/data/421/200/285/421200285.geojson
@@ -29,8 +29,14 @@
     "name:ceb_x_preferred":[
         "Kesra"
     ],
+    "name:deu_x_preferred":[
+        "Kesra"
+    ],
     "name:eng_x_preferred":[
         "Kesra"
+    ],
+    "name:fas_x_preferred":[
+        "\u06a9\u0633\u0631\u06cc"
     ],
     "name:fra_x_preferred":[
         "Kesra"
@@ -38,11 +44,20 @@
     "name:nld_x_preferred":[
         "Kesra"
     ],
+    "name:spa_x_preferred":[
+        "Kesra"
+    ],
+    "name:tur_x_preferred":[
+        "Kisra"
+    ],
     "name:ukr_x_preferred":[
         "\u041a\u0435\u0441\u0440\u0430"
     ],
     "name:und_x_variant":[
         "Kisrah"
+    ],
+    "name:zul_x_preferred":[
+        "Kesra"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -92,7 +107,7 @@
         }
     ],
     "wof:id":421200285,
-    "wof:lastmodified":1566667317,
+    "wof:lastmodified":1690874856,
     "wof:name":"Kesra",
     "wof:parent_id":1108757669,
     "wof:placetype":"locality",

--- a/data/421/200/287/421200287.geojson
+++ b/data/421/200/287/421200287.geojson
@@ -29,6 +29,9 @@
     "name:ceb_x_preferred":[
         "Jamm\u0101l"
     ],
+    "name:deu_x_preferred":[
+        "Jemmal"
+    ],
     "name:eng_x_preferred":[
         "Jemmal"
     ],
@@ -50,6 +53,9 @@
     "name:rus_x_preferred":[
         "\u0414\u0436\u0430\u043c\u0430\u043b\u044c"
     ],
+    "name:tur_x_preferred":[
+        "Cemal"
+    ],
     "name:ukr_x_preferred":[
         "\u0414\u0436\u0435\u043c\u043c\u0430\u043b\u044c"
     ],
@@ -58,6 +64,9 @@
     ],
     "name:urd_x_preferred":[
         "\u062c\u0645\u0627\u0644"
+    ],
+    "name:zul_x_preferred":[
+        "Jemmal"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -107,7 +116,7 @@
         }
     ],
     "wof:id":421200287,
-    "wof:lastmodified":1566667316,
+    "wof:lastmodified":1690874854,
     "wof:name":"Jammal",
     "wof:parent_id":1108757537,
     "wof:placetype":"locality",

--- a/data/421/200/289/421200289.geojson
+++ b/data/421/200/289/421200289.geojson
@@ -20,20 +20,32 @@
     "name:ara_x_preferred":[
         "\u0645\u0646\u0632\u0644 \u0633\u0627\u0644\u0645"
     ],
+    "name:cat_x_preferred":[
+        "Menzel Salem"
+    ],
     "name:ceb_x_preferred":[
         "Manzil S\u0101lim"
     ],
     "name:eng_x_preferred":[
         "Menzel Salem"
     ],
+    "name:fas_x_preferred":[
+        "\u0645\u0646\u0632\u0644 \u0633\u0627\u0644\u0645"
+    ],
     "name:fra_x_preferred":[
         "Menzel Salem"
+    ],
+    "name:tur_x_preferred":[
+        "Menzil Salim"
     ],
     "name:ukr_x_preferred":[
         "\u041c\u0435\u043d\u0437\u0435\u043b\u044c-\u0421\u0430\u043b\u0435\u043c"
     ],
     "name:und_x_variant":[
         "S\u012bd\u012b \u2018Umar Bin S\u0101lim"
+    ],
+    "name:zul_x_preferred":[
+        "Menzel Salem"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -83,7 +95,7 @@
         }
     ],
     "wof:id":421200289,
-    "wof:lastmodified":1566667316,
+    "wof:lastmodified":1690874855,
     "wof:name":"Manzil Salim",
     "wof:parent_id":1108757465,
     "wof:placetype":"locality",

--- a/data/421/200/291/421200291.geojson
+++ b/data/421/200/291/421200291.geojson
@@ -23,8 +23,14 @@
     "name:azb_x_preferred":[
         "\u0645\u0646\u0632\u0644 \u06a9\u0627\u0645\u0644"
     ],
+    "name:cat_x_preferred":[
+        "Menzel Kamel"
+    ],
     "name:ceb_x_preferred":[
         "Manzil K\u0101mil"
+    ],
+    "name:deu_x_preferred":[
+        "Menzel Kamel"
     ],
     "name:eng_x_preferred":[
         "Menzel Kamel"
@@ -38,8 +44,14 @@
     "name:rus_x_preferred":[
         "\u041c\u0435\u043d\u0437\u0435\u043b\u044c-\u041a\u0430\u043c\u0435\u043b\u044c"
     ],
+    "name:tur_x_preferred":[
+        "Menzil Kamil"
+    ],
     "name:ukr_x_preferred":[
         "\u041c\u0435\u043d\u0437\u0435\u043b\u044c-\u041a\u0430\u043c\u0435\u043b\u044c"
+    ],
+    "name:zul_x_preferred":[
+        "Menzel Kamel"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -89,7 +101,7 @@
         }
     ],
     "wof:id":421200291,
-    "wof:lastmodified":1566667317,
+    "wof:lastmodified":1690874856,
     "wof:name":"Manzil Kamil",
     "wof:parent_id":1108757537,
     "wof:placetype":"locality",

--- a/data/421/200/295/421200295.geojson
+++ b/data/421/200/295/421200295.geojson
@@ -29,6 +29,9 @@
     "name:eng_x_preferred":[
         "Sidi Alouane"
     ],
+    "name:fas_x_preferred":[
+        "\u0633\u06cc\u062f\u06cc \u0639\u0644\u0648\u0627\u0646"
+    ],
     "name:fra_x_preferred":[
         "Sidi Alouane"
     ],
@@ -41,11 +44,17 @@
     "name:ron_x_preferred":[
         "Sidi Alouane"
     ],
+    "name:tur_x_preferred":[
+        "Sidi Elvan"
+    ],
     "name:ukr_x_preferred":[
         "\u0421\u0456\u0434\u0456-\u0410\u043b\u044e\u0430\u043d"
     ],
     "name:und_x_variant":[
         "Sidi Allouane"
+    ],
+    "name:zul_x_preferred":[
+        "Sidi Alouane"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -95,7 +104,7 @@
         }
     ],
     "wof:id":421200295,
-    "wof:lastmodified":1566667316,
+    "wof:lastmodified":1690874855,
     "wof:name":"Sidi Ulwan",
     "wof:parent_id":1108757487,
     "wof:placetype":"locality",

--- a/data/421/200/299/421200299.geojson
+++ b/data/421/200/299/421200299.geojson
@@ -26,8 +26,14 @@
     "name:ceb_x_preferred":[
         "Sidi el Hani"
     ],
+    "name:deu_x_preferred":[
+        "Sidi El H\u00e9ni"
+    ],
     "name:eng_x_preferred":[
         "Sidi El Hani"
+    ],
+    "name:fas_x_preferred":[
+        "\u0633\u06cc\u062f\u06cc \u0627\u0644\u0647\u0627\u0646\u06cc"
     ],
     "name:fra_x_preferred":[
         "Sidi El Hani"
@@ -41,11 +47,17 @@
     "name:rus_x_preferred":[
         "\u0421\u0438\u0434\u0438 \u044d\u043b\u044c \u042d\u043d\u0438"
     ],
+    "name:tur_x_preferred":[
+        "Sidi\u00fc'l-Hani"
+    ],
     "name:ukr_x_preferred":[
         "\u0421\u0456\u0434\u0456-\u0435\u043b\u044c-\u0413\u0430\u043d\u0456"
     ],
     "name:und_x_variant":[
         "El Hani"
+    ],
+    "name:zul_x_preferred":[
+        "Sidi El Hani"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -95,7 +107,7 @@
         }
     ],
     "wof:id":421200299,
-    "wof:lastmodified":1566667317,
+    "wof:lastmodified":1690874856,
     "wof:name":"Sidi al Hani'",
     "wof:parent_id":1108757705,
     "wof:placetype":"locality",

--- a/data/421/200/301/421200301.geojson
+++ b/data/421/200/301/421200301.geojson
@@ -56,10 +56,19 @@
     "name:hye_x_preferred":[
         "\u0544\u0565\u0576\u0566\u0565\u056c \u0532\u0578\u0582\u0580\u0563\u056b\u0562\u0561"
     ],
+    "name:jpn_x_preferred":[
+        "\u30e1\u30f3\u30bc\u30eb\u30fb\u30d6\u30eb\u30ae\u30d0"
+    ],
     "name:kor_x_preferred":[
         "\uba58\uc824\ubd80\ub974\uae30\ubc14"
     ],
+    "name:ltz_x_preferred":[
+        "Menzel Bourguiba"
+    ],
     "name:nld_x_preferred":[
+        "Menzel Bourguiba"
+    ],
+    "name:nob_x_preferred":[
         "Menzel Bourguiba"
     ],
     "name:oci_x_preferred":[
@@ -89,6 +98,9 @@
     "name:swe_x_preferred":[
         "Menzel Bourguiba"
     ],
+    "name:szl_x_preferred":[
+        "Manzil Bu Rukajba"
+    ],
     "name:tur_x_preferred":[
         "Menzel Burgiba"
     ],
@@ -98,11 +110,17 @@
     "name:und_x_variant":[
         "Bourguiba"
     ],
+    "name:urd_x_preferred":[
+        "\u0645\u0646\u0632\u0644 \u0628\u0648\u0631\u0642\u06cc\u0628\u06c1"
+    ],
     "name:uzb_x_preferred":[
         "Menzel Bourguiba"
     ],
     "name:zho_x_preferred":[
         "\u5e03\u723e\u5409\u5df4\u71df"
+    ],
+    "name:zul_x_preferred":[
+        "Menzel Bourguiba"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -151,7 +169,7 @@
         }
     ],
     "wof:id":421200301,
-    "wof:lastmodified":1566667316,
+    "wof:lastmodified":1690874854,
     "wof:name":"Sidi Fath Allah",
     "wof:parent_id":1108757297,
     "wof:placetype":"locality",

--- a/data/421/200/577/421200577.geojson
+++ b/data/421/200/577/421200577.geojson
@@ -29,17 +29,32 @@
     "name:cym_x_preferred":[
         "M\u00e9grine"
     ],
+    "name:deu_x_preferred":[
+        "M\u00e9grine"
+    ],
     "name:eng_x_preferred":[
         "M\u00e9grine"
     ],
+    "name:fas_x_preferred":[
+        "\u0645\u0642\u0631\u06cc\u0646"
+    ],
     "name:fra_x_preferred":[
         "M\u00e9grine"
+    ],
+    "name:ita_x_preferred":[
+        "M\u00e9grine"
+    ],
+    "name:tur_x_preferred":[
+        "Mukrin"
     ],
     "name:ukr_x_preferred":[
         "\u041c\u0435\u043a\u0440\u0456\u043d"
     ],
     "name:und_x_variant":[
         "Maqr\u012bn"
+    ],
+    "name:zul_x_preferred":[
+        "M\u00e9grine"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -87,7 +102,7 @@
         }
     ],
     "wof:id":421200577,
-    "wof:lastmodified":1566667317,
+    "wof:lastmodified":1690874856,
     "wof:name":"Maqrin",
     "wof:parent_id":1108757271,
     "wof:placetype":"locality",

--- a/data/421/200/581/421200581.geojson
+++ b/data/421/200/581/421200581.geojson
@@ -50,6 +50,9 @@
     "name:eng_x_preferred":[
         "Ben Arous"
     ],
+    "name:est_x_preferred":[
+        "Bin \u02bfAr\u016bs"
+    ],
     "name:fas_x_preferred":[
         "\u0628\u0646 \u0639\u0631\u0648\u0633"
     ],
@@ -59,8 +62,14 @@
     "name:fra_x_preferred":[
         "Ben Arous"
     ],
+    "name:gle_x_preferred":[
+        "Ben Arous"
+    ],
     "name:guj_x_preferred":[
         "\u0aac\u0ac7\u0aa8 \u0a8f\u0ab0\u0ab8"
+    ],
+    "name:heb_x_preferred":[
+        "\u05d1\u05df \u05e2\u05e8\u05d5\u05e1"
     ],
     "name:hin_x_preferred":[
         "\u092c\u0947\u0928 \u0905\u0930\u094c\u0938"
@@ -137,6 +146,9 @@
     "name:tha_x_preferred":[
         "\u0e40\u0e1a\u0e19\u0e2d\u0e32\u0e23\u0e38\u0e2a"
     ],
+    "name:tha_x_variant":[
+        "\u0e1a\u0e34\u0e19\u0e2d\u0e30\u0e23\u0e39\u0e2a"
+    ],
     "name:tur_x_preferred":[
         "Ben Arus"
     ],
@@ -154,6 +166,9 @@
     ],
     "name:zho_x_preferred":[
         "\u672c\u963f\u9c81\u65af"
+    ],
+    "name:zul_x_preferred":[
+        "Ben Arous"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPLA",
@@ -204,7 +219,7 @@
         }
     ],
     "wof:id":421200581,
-    "wof:lastmodified":1566667316,
+    "wof:lastmodified":1690874855,
     "wof:name":"Bin Arus",
     "wof:parent_id":1108757271,
     "wof:placetype":"locality",

--- a/data/421/200/583/421200583.geojson
+++ b/data/421/200/583/421200583.geojson
@@ -35,6 +35,9 @@
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0411\u0456\u0437\u0435\u0440\u0442\u0430"
     ],
+    "name:bel_x_variant":[
+        "\u0411\u0456\u0437\u0435\u0440\u0442\u0430"
+    ],
     "name:ben_x_preferred":[
         "\u09ac\u09bf\u099c\u09c7\u09b0\u09a4\u09c7"
     ],
@@ -46,6 +49,9 @@
     ],
     "name:cat_x_preferred":[
         "Bizerta"
+    ],
+    "name:ceb_x_preferred":[
+        "Bizerte"
     ],
     "name:ces_x_preferred":[
         "Bizerta"
@@ -83,6 +89,9 @@
     "name:fra_x_preferred":[
         "Bizerte"
     ],
+    "name:fry_x_preferred":[
+        "Bizerte"
+    ],
     "name:gle_x_preferred":[
         "Bizerte"
     ],
@@ -97,6 +106,9 @@
     ],
     "name:hun_x_preferred":[
         "Bizerte"
+    ],
+    "name:hye_x_preferred":[
+        "\u0532\u056b\u0566\u0565\u0580\u057f\u0565"
     ],
     "name:ind_x_preferred":[
         "Bizerte"
@@ -133,6 +145,9 @@
     ],
     "name:mar_x_preferred":[
         "\u092c\u093f\u091d\u0930\u094d\u091f\u0947"
+    ],
+    "name:mdf_x_preferred":[
+        "\u0411\u0438\u0437\u044d\u200e\u0440\u0442\u0430"
     ],
     "name:msa_x_preferred":[
         "Bizerte"
@@ -173,6 +188,9 @@
     "name:swe_x_preferred":[
         "Bizerte"
     ],
+    "name:szl_x_preferred":[
+        "Bizerta"
+    ],
     "name:tam_x_preferred":[
         "\u0baa\u0bbf\u0bb8\u0bbf\u0bb0\u0bcd\u0b9f\u0bc7"
     ],
@@ -184,6 +202,9 @@
     ],
     "name:tha_x_preferred":[
         "\u0e1a\u0e34\u0e40\u0e0b\u0e2d\u0e23\u0e4c\u0e40\u0e15"
+    ],
+    "name:tha_x_variant":[
+        "\u0e1a\u0e31\u0e19\u0e0b\u0e31\u0e23\u0e15\u0e4c"
     ],
     "name:tur_x_preferred":[
         "Bizerte"
@@ -208,6 +229,9 @@
     ],
     "name:zho_x_preferred":[
         "\u6bd4\u585e\u5927"
+    ],
+    "name:zul_x_preferred":[
+        "Bizerte"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Tunisia",
@@ -351,7 +375,7 @@
         }
     ],
     "wof:id":421200583,
-    "wof:lastmodified":1566667317,
+    "wof:lastmodified":1690874857,
     "wof:name":"Bizerte",
     "wof:parent_id":1108757281,
     "wof:placetype":"locality",

--- a/data/421/201/009/421201009.geojson
+++ b/data/421/201/009/421201009.geojson
@@ -80,6 +80,9 @@
     "name:hun_x_preferred":[
         "Arj\u00e1na"
     ],
+    "name:hye_x_preferred":[
+        "\u0531\u0580\u0575\u0561\u0576\u0561"
+    ],
     "name:ind_x_preferred":[
         "Aryanah"
     ],
@@ -143,6 +146,9 @@
     "name:spa_x_preferred":[
         "Ariana"
     ],
+    "name:swa_x_preferred":[
+        "Aryanah"
+    ],
     "name:swe_x_preferred":[
         "Ariana"
     ],
@@ -154,6 +160,9 @@
     ],
     "name:tha_x_preferred":[
         "\u0e2d\u0e32\u0e40\u0e23\u0e35\u0e22\u0e19\u0e32"
+    ],
+    "name:tha_x_variant":[
+        "\u0e2d\u0e31\u0e23\u0e22\u0e32\u0e19\u0e30\u0e2e\u0e4c"
     ],
     "name:tur_x_preferred":[
         "Aryana"
@@ -175,6 +184,9 @@
     ],
     "name:zho_x_preferred":[
         "\u827e\u5c14\u4e9a\u5948"
+    ],
+    "name:zul_x_preferred":[
+        "Aryanah"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPLA",
@@ -233,7 +245,7 @@
         }
     ],
     "wof:id":421201009,
-    "wof:lastmodified":1566667317,
+    "wof:lastmodified":1690874857,
     "wof:name":"Aryanah",
     "wof:parent_id":1108757243,
     "wof:placetype":"locality",

--- a/data/421/201/981/421201981.geojson
+++ b/data/421/201/981/421201981.geojson
@@ -23,6 +23,9 @@
     "name:ara_x_variant":[
         "\u06a8\u0628\u0644\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0642\u0628\u0644\u0649"
+    ],
     "name:cat_x_preferred":[
         "K\u00e9bili"
     ],
@@ -47,11 +50,20 @@
     "name:eng_x_preferred":[
         "Kebili"
     ],
+    "name:fas_x_preferred":[
+        "\u0642\u0628\u0644\u06cc"
+    ],
     "name:fra_x_preferred":[
         "K\u00e9bili"
     ],
+    "name:heb_x_preferred":[
+        "\u05e7\u05d1\u05d9\u05dc\u05d9"
+    ],
     "name:ita_x_preferred":[
         "K\u00e9bili"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30b1\u30d3\u30ea"
     ],
     "name:kor_x_preferred":[
         "\ucf00\ube4c\ub9ac"
@@ -80,6 +92,9 @@
     "name:spa_x_preferred":[
         "Kebili"
     ],
+    "name:tha_x_preferred":[
+        "\u0e01\u0e34\u0e1a\u0e34\u0e25\u0e25\u0e35"
+    ],
     "name:tur_x_preferred":[
         "Kabili"
     ],
@@ -94,6 +109,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5409\u6bd4\u5229"
+    ],
+    "name:zul_x_preferred":[
+        "Kebili"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Tunisia",
@@ -235,7 +253,7 @@
         }
     ],
     "wof:id":421201981,
-    "wof:lastmodified":1566667317,
+    "wof:lastmodified":1690874857,
     "wof:name":"Qibili",
     "wof:parent_id":1108757437,
     "wof:placetype":"locality",

--- a/data/421/202/391/421202391.geojson
+++ b/data/421/202/391/421202391.geojson
@@ -29,6 +29,9 @@
     "name:eng_x_preferred":[
         "Sidi Bou Ali"
     ],
+    "name:fas_x_preferred":[
+        "\u0633\u06cc\u062f\u06cc \u0628\u0648\u0639\u0644\u06cc"
+    ],
     "name:fra_x_preferred":[
         "Sidi Bou Ali"
     ],
@@ -38,11 +41,17 @@
     "name:ron_x_preferred":[
         "Sidi Bou Ali"
     ],
+    "name:tur_x_preferred":[
+        "Sidi Bu Ali"
+    ],
     "name:ukr_x_preferred":[
         "\u0421\u0456\u0434\u0456-\u0431\u0443-\u0410\u043b\u0456"
     ],
     "name:und_x_variant":[
         "S\u012bd\u012b B\u016b \u2018Al\u012b"
+    ],
+    "name:zul_x_preferred":[
+        "Sidi Bou Ali"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -92,7 +101,7 @@
         }
     ],
     "wof:id":421202391,
-    "wof:lastmodified":1566667307,
+    "wof:lastmodified":1690874845,
     "wof:name":"Sidi Bu Ali",
     "wof:parent_id":1108757703,
     "wof:placetype":"locality",

--- a/data/421/202/449/421202449.geojson
+++ b/data/421/202/449/421202449.geojson
@@ -29,7 +29,13 @@
     "name:ceb_x_preferred":[
         "Kelaa Kebira"
     ],
+    "name:deu_x_preferred":[
+        "Kal\u00e2a K\u00e9bira"
+    ],
     "name:eng_x_preferred":[
+        "Kal\u00e2a Kebira"
+    ],
+    "name:eus_x_preferred":[
         "Kal\u00e2a Kebira"
     ],
     "name:fas_x_preferred":[
@@ -58,6 +64,9 @@
     ],
     "name:urd_x_preferred":[
         "\u0627\u0644\u0642\u0644\u0639\u06c3 \u0627\u0644\u06a9\u0628\u0631\u06cc"
+    ],
+    "name:zul_x_preferred":[
+        "Kal\u00e2a Kebira"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -105,7 +114,7 @@
         }
     ],
     "wof:id":421202449,
-    "wof:lastmodified":1566667307,
+    "wof:lastmodified":1690874846,
     "wof:name":"Al Qalah al Kubra",
     "wof:parent_id":1108757695,
     "wof:placetype":"locality",

--- a/data/421/203/019/421203019.geojson
+++ b/data/421/203/019/421203019.geojson
@@ -20,14 +20,23 @@
     "name:ara_x_preferred":[
         "\u0634\u0646\u0646\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0634\u0646\u0646\u0649"
+    ],
     "name:bul_x_preferred":[
         "\u0428\u0435\u043d\u0438\u043d\u0438"
+    ],
+    "name:cat_x_preferred":[
+        "Chenini"
     ],
     "name:deu_x_preferred":[
         "Chenini"
     ],
     "name:eng_x_preferred":[
         "Chenini"
+    ],
+    "name:fas_x_preferred":[
+        "\u0634\u0646\u0646\u06cc"
     ],
     "name:fra_x_preferred":[
         "Chenini"
@@ -43,6 +52,12 @@
     ],
     "name:rus_x_preferred":[
         "\u0428\u0435\u043d\u0438\u043d\u0438"
+    ],
+    "name:spa_x_preferred":[
+        "Chenini"
+    ],
+    "name:tur_x_preferred":[
+        "\u015eenini"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -91,7 +106,7 @@
         }
     ],
     "wof:id":421203019,
-    "wof:lastmodified":1566667306,
+    "wof:lastmodified":1690874844,
     "wof:name":"Shanini",
     "wof:parent_id":1108757733,
     "wof:placetype":"locality",

--- a/data/421/203/059/421203059.geojson
+++ b/data/421/203/059/421203059.geojson
@@ -41,6 +41,9 @@
     "name:fra_x_preferred":[
         "Hammam Lif"
     ],
+    "name:heb_x_preferred":[
+        "\u05d7\u05de\u05d0\u05dd \u05dc\u05d9\u05e3"
+    ],
     "name:hun_x_preferred":[
         "Hammam-Lif"
     ],
@@ -49,6 +52,9 @@
     ],
     "name:ita_x_variant":[
         "Hammam Lif"
+    ],
+    "name:lit_x_preferred":[
+        "Hamam Lifas"
     ],
     "name:mar_x_preferred":[
         "Mahdia"
@@ -68,6 +74,9 @@
     "name:spa_x_preferred":[
         "Hammam Lif"
     ],
+    "name:tur_x_preferred":[
+        "Hamam\u00fc'l-Linf"
+    ],
     "name:ukr_x_preferred":[
         "\u0425\u0430\u043c\u043c\u0430\u043c-\u041b\u0456\u0444"
     ],
@@ -76,6 +85,9 @@
     ],
     "name:zho_x_preferred":[
         "\u54c8\u9a6c\u59c6\u5229\u592b"
+    ],
+    "name:zul_x_preferred":[
+        "Hammam-Lif"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -124,7 +136,7 @@
         }
     ],
     "wof:id":421203059,
-    "wof:lastmodified":1566667306,
+    "wof:lastmodified":1690874844,
     "wof:name":"Hammam al Anf",
     "wof:parent_id":1108757271,
     "wof:placetype":"locality",

--- a/data/421/203/061/421203061.geojson
+++ b/data/421/203/061/421203061.geojson
@@ -50,7 +50,16 @@
     "name:ell_x_preferred":[
         "\u0391\u03bb \u039c\u03b1\u03bd\u03c4\u03af\u03b3\u03b9\u03b1"
     ],
+    "name:ell_x_variant":[
+        "\u039c\u03b1\u03c7\u03bd\u03c4\u03af\u03b1"
+    ],
     "name:eng_x_preferred":[
+        "Mahdia"
+    ],
+    "name:epo_x_preferred":[
+        "Mahdia"
+    ],
+    "name:eus_x_preferred":[
         "Mahdia"
     ],
     "name:fas_x_preferred":[
@@ -60,6 +69,9 @@
         "Mahdia"
     ],
     "name:fra_x_preferred":[
+        "Mahdia"
+    ],
+    "name:glg_x_preferred":[
         "Mahdia"
     ],
     "name:guj_x_preferred":[
@@ -110,8 +122,14 @@
     "name:nld_x_preferred":[
         "Mahdia"
     ],
+    "name:nno_x_preferred":[
+        "Mahdia"
+    ],
     "name:nob_x_preferred":[
         "Mahdia"
+    ],
+    "name:pnb_x_preferred":[
+        "\u0645\u06c1\u062f\u06cc\u06c1"
     ],
     "name:pol_x_preferred":[
         "Al-Mahdijja"
@@ -143,6 +161,9 @@
     "name:spa_x_preferred":[
         "Mahdia"
     ],
+    "name:spa_x_variant":[
+        "Mahd\u00eda"
+    ],
     "name:swe_x_preferred":[
         "Mahdia"
     ],
@@ -154,6 +175,9 @@
     ],
     "name:tha_x_preferred":[
         "\u0e21\u0e32\u0e2b\u0e4c\u0e40\u0e14\u0e35\u0e22"
+    ],
+    "name:tha_x_variant":[
+        "\u0e2d\u0e31\u0e25\u0e21\u0e30\u0e2e\u0e4c\u0e14\u0e35\u0e22\u0e30\u0e2e\u0e4c"
     ],
     "name:tur_x_preferred":[
         "Mehdiye"
@@ -172,6 +196,9 @@
     ],
     "name:zho_x_preferred":[
         "\u9a6c\u8d6b\u8fea\u8036"
+    ],
+    "name:zul_x_preferred":[
+        "Mahdia"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPLA",
@@ -221,7 +248,7 @@
         }
     ],
     "wof:id":421203061,
-    "wof:lastmodified":1566667306,
+    "wof:lastmodified":1690874844,
     "wof:name":"Al Mahdiyah",
     "wof:parent_id":1108757481,
     "wof:placetype":"locality",

--- a/data/421/203/071/421203071.geojson
+++ b/data/421/203/071/421203071.geojson
@@ -59,6 +59,9 @@
     "name:kor_x_preferred":[
         "\ub974\ubc14\ub974\ub3c4"
     ],
+    "name:lit_x_preferred":[
+        "Le Bardas"
+    ],
     "name:nld_x_preferred":[
         "Le Bardo"
     ],
@@ -74,14 +77,23 @@
     "name:pol_x_preferred":[
         "Bardau"
     ],
+    "name:rus_x_preferred":[
+        "\u0411\u0430\u0440\u0434\u043e"
+    ],
     "name:sco_x_preferred":[
         "Le Bardo"
     ],
     "name:spa_x_preferred":[
         "Le Bardo"
     ],
+    "name:swe_x_preferred":[
+        "Le Bardo"
+    ],
     "name:szl_x_preferred":[
         "Le Bardo"
+    ],
+    "name:tur_x_preferred":[
+        "Bardo"
     ],
     "name:ukr_x_preferred":[
         "\u0411\u0430\u0440\u0434\u043e"
@@ -94,6 +106,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5df4\u723e\u675c"
+    ],
+    "name:zul_x_preferred":[
+        "Le Bardo"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -141,7 +156,7 @@
         }
     ],
     "wof:id":421203071,
-    "wof:lastmodified":1566667305,
+    "wof:lastmodified":1690874843,
     "wof:name":"Bardaw",
     "wof:parent_id":1108757755,
     "wof:placetype":"locality",

--- a/data/421/203/073/421203073.geojson
+++ b/data/421/203/073/421203073.geojson
@@ -29,8 +29,17 @@
     "name:ceb_x_preferred":[
         "Gh\u0101r al Mil\u1e29"
     ],
+    "name:deu_x_preferred":[
+        "Ghar El Melh"
+    ],
     "name:eng_x_preferred":[
         "Ghar al Milh"
+    ],
+    "name:eng_x_variant":[
+        "Ghar el-Melh"
+    ],
+    "name:fas_x_preferred":[
+        "\u063a\u0627\u0631 \u0627\u0644\u0645\u0644\u062d"
     ],
     "name:fra_x_preferred":[
         "Ghar El Melh"
@@ -38,11 +47,17 @@
     "name:ita_x_preferred":[
         "Ghar El Melh"
     ],
+    "name:jpn_x_preferred":[
+        "\u30ac\u30fc\u30eb\u30fb\u30a8\u30eb\uff1d\u30e1\u30eb\u30d5"
+    ],
     "name:nld_x_preferred":[
         "Ghar al Milh"
     ],
     "name:rus_x_preferred":[
         "\u0413\u0430\u0440-\u044d\u043b\u044c-\u041c\u0435\u043b\u0430"
+    ],
+    "name:rus_x_variant":[
+        "\u0413\u0430\u0440-\u044d\u043b\u044c-\u041c\u0435\u043b\u0430\u0445"
     ],
     "name:tur_x_preferred":[
         "\u011ear el-Mileh"
@@ -52,6 +67,9 @@
     ],
     "name:und_x_variant":[
         "Ruscania"
+    ],
+    "name:zul_x_preferred":[
+        "Ghar el-Melh"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -101,7 +119,7 @@
         }
     ],
     "wof:id":421203073,
-    "wof:lastmodified":1566667306,
+    "wof:lastmodified":1690874843,
     "wof:name":"Ghar al Milh",
     "wof:parent_id":1108757287,
     "wof:placetype":"locality",

--- a/data/421/203/075/421203075.geojson
+++ b/data/421/203/075/421203075.geojson
@@ -35,6 +35,9 @@
     "name:eng_x_preferred":[
         "Korbous"
     ],
+    "name:fas_x_preferred":[
+        "\u0642\u0631\u0628\u0635"
+    ],
     "name:fin_x_preferred":[
         "Korbous"
     ],
@@ -56,11 +59,17 @@
     "name:swe_x_preferred":[
         "Korbous"
     ],
+    "name:tur_x_preferred":[
+        "Kurbus"
+    ],
     "name:ukr_x_preferred":[
         "\u041a\u043e\u0440\u0431\u0443\u0441"
     ],
     "name:und_x_variant":[
         "Korbous Dar el Oudiane"
+    ],
+    "name:zul_x_preferred":[
+        "Korbous"
     ],
     "qs:gn_country":"TN",
     "qs:gn_fcode":"PPL",
@@ -109,7 +118,7 @@
         }
     ],
     "wof:id":421203075,
-    "wof:lastmodified":1566667306,
+    "wof:lastmodified":1690874844,
     "wof:name":"Qurbus",
     "wof:parent_id":1108757591,
     "wof:placetype":"locality",

--- a/data/856/327/03/85632703.geojson
+++ b/data/856/327/03/85632703.geojson
@@ -28,6 +28,9 @@
     "mz:is_current":1,
     "mz:max_zoom":8.0,
     "mz:min_zoom":3.0,
+    "name:abk_x_preferred":[
+        "\u0422\u0443\u043d\u0438\u0441"
+    ],
     "name:ace_x_preferred":[
         "Tunisia"
     ],
@@ -49,8 +52,14 @@
     "name:amh_x_preferred":[
         "\u1271\u1292\u12da\u12eb"
     ],
+    "name:ami_x_preferred":[
+        "Tunisia"
+    ],
     "name:ang_x_preferred":[
         "Tunisia"
+    ],
+    "name:anp_x_preferred":[
+        "\u091f\u094d\u092f\u0942\u0928\u0940\u0936\u093f\u092f\u093e"
     ],
     "name:ara_x_preferred":[
         "\u062a\u0648\u0646\u0633"
@@ -65,6 +74,9 @@
     "name:arg_x_preferred":[
         "Tunicia"
     ],
+    "name:arq_x_preferred":[
+        "\u062a\u0648\u0646\u0633"
+    ],
     "name:ary_x_preferred":[
         "\u062a\u0648\u0646\u0633"
     ],
@@ -76,6 +88,9 @@
     ],
     "name:ast_x_variant":[
         "Tunicia"
+    ],
+    "name:avk_x_preferred":[
+        "Tunusa"
     ],
     "name:azb_x_preferred":[
         "\u062a\u0648\u0646\u06cc\u0633"
@@ -95,6 +110,9 @@
     "name:ban_x_preferred":[
         "Tunisia"
     ],
+    "name:bar_x_preferred":[
+        "Tunesien"
+    ],
     "name:bcl_x_preferred":[
         "Tunisya"
     ],
@@ -109,6 +127,9 @@
     ],
     "name:bho_x_preferred":[
         "\u091f\u094d\u092f\u0942\u0928\u0940\u0936\u093f\u092f\u093e"
+    ],
+    "name:bis_x_preferred":[
+        "Tunisia"
     ],
     "name:bjn_x_preferred":[
         "Tunisia"
@@ -179,6 +200,9 @@
     "name:cze_x_variant":[
         "T\u00fanez"
     ],
+    "name:dag_x_preferred":[
+        "Tunisia"
+    ],
     "name:dan_x_preferred":[
         "Tunesien"
     ],
@@ -202,6 +226,9 @@
     ],
     "name:div_x_preferred":[
         "\u078c\u07ab\u0782\u07a8\u0790\u07b0"
+    ],
+    "name:dsb_x_preferred":[
+        "Tuneziska"
     ],
     "name:dty_x_preferred":[
         "\u091f\u094d\u092f\u0941\u0928\u093f\u0938\u093f\u092f\u093e"
@@ -276,6 +303,9 @@
     "name:ful_x_preferred":[
         "Tunisii"
     ],
+    "name:ful_x_variant":[
+        "Tuniisi"
+    ],
     "name:gag_x_preferred":[
         "Tunis"
     ],
@@ -299,6 +329,15 @@
     ],
     "name:gom_x_preferred":[
         "\u091f\u094d\u092f\u0941\u0928\u093f\u0936\u093f\u092f\u093e"
+    ],
+    "name:gor_x_preferred":[
+        "Tunisia"
+    ],
+    "name:gpe_x_preferred":[
+        "Tunisia"
+    ],
+    "name:grn_x_preferred":[
+        "Tun\u00edsia"
     ],
     "name:gsw_x_preferred":[
         "Tunesie"
@@ -352,6 +391,9 @@
     ],
     "name:hyw_x_preferred":[
         "\u0539\u0578\u0582\u0576\u056b\u057d"
+    ],
+    "name:hyw_x_variant":[
+        "\u0539\u0578\u0582\u0576\u0578\u0582\u0566"
     ],
     "name:ibo_x_preferred":[
         "Tunisia"
@@ -437,6 +479,9 @@
     "name:kor_x_preferred":[
         "\ud280\ub2c8\uc9c0"
     ],
+    "name:krj_x_preferred":[
+        "Tunes"
+    ],
     "name:kur_x_preferred":[
         "T\u00fbnis"
     ],
@@ -476,6 +521,9 @@
     "name:lit_x_preferred":[
         "Tunisas"
     ],
+    "name:lld_x_preferred":[
+        "Tunisia"
+    ],
     "name:lmo_x_preferred":[
         "T\u00fcnisia"
     ],
@@ -494,6 +542,9 @@
     "name:lzh_x_preferred":[
         "\u7a81\u5c3c\u65af"
     ],
+    "name:mad_x_preferred":[
+        "Tunisia"
+    ],
     "name:mal_x_preferred":[
         "\u0d1f\u0d41\u0d23\u0d40\u0d37\u0d4d\u0d2f"
     ],
@@ -504,6 +555,12 @@
         "\u091f\u094d\u092f\u0942\u0928\u093f\u0936\u093f\u092f\u093e"
     ],
     "name:mdf_x_preferred":[
+        "\u0422\u0443\u043d\u0438\u0441"
+    ],
+    "name:mdf_x_variant":[
+        "\u0422\u0443\u043d\u0438\u0441\u0438\u044f"
+    ],
+    "name:mhr_x_preferred":[
         "\u0422\u0443\u043d\u0438\u0441"
     ],
     "name:min_x_preferred":[
@@ -520,6 +577,9 @@
     ],
     "name:mlt_x_variant":[
         "Tune\u017c"
+    ],
+    "name:mni_x_preferred":[
+        "\uabc7\uabe8\uabc5\uabe4\uabc1\uabe4\uabcc\uabe5"
     ],
     "name:mon_x_preferred":[
         "\u0422\u0443\u043d\u0438\u0441"
@@ -539,6 +599,9 @@
     "name:mya_x_variant":[
         "\u1010\u1030\u1014\u102e\u1038\u101b\u103e\u102c\u1038"
     ],
+    "name:myv_x_preferred":[
+        "\u0422\u0443\u043d\u0438\u0441"
+    ],
     "name:mzn_x_preferred":[
         "\u062a\u0648\u0646\u0633"
     ],
@@ -546,6 +609,9 @@
         "Tunez"
     ],
     "name:nan_x_preferred":[
+        "Tunisia"
+    ],
+    "name:nau_x_preferred":[
         "Tunisia"
     ],
     "name:nde_x_preferred":[
@@ -584,6 +650,9 @@
     "name:nov_x_preferred":[
         "Tunisia"
     ],
+    "name:nqo_x_preferred":[
+        "\u07d5\u07ce\u07f3\u07e3\u07d1\u07d6\u07ed\u07cc"
+    ],
     "name:nso_x_preferred":[
         "Tunisia"
     ],
@@ -617,6 +686,9 @@
     ],
     "name:pap_x_preferred":[
         "Tunesia"
+    ],
+    "name:pcd_x_preferred":[
+        "Tunisie"
     ],
     "name:pih_x_preferred":[
         "Tunisia"
@@ -684,6 +756,9 @@
     "name:sgs_x_preferred":[
         "Ton\u0117sos"
     ],
+    "name:shi_x_preferred":[
+        "Tuns"
+    ],
     "name:sin_x_preferred":[
         "\u0da7\u0dd2\u0dba\u0dd4\u0db1\u0dd3\u0dc3\u0dd2\u0dba\u0dcf\u0dc0"
     ],
@@ -696,7 +771,13 @@
     "name:sme_x_preferred":[
         "Tunisia"
     ],
+    "name:smn_x_preferred":[
+        "Tunisia"
+    ],
     "name:smo_x_preferred":[
+        "Tunisia"
+    ],
+    "name:sms_x_preferred":[
         "Tunisia"
     ],
     "name:sna_x_preferred":[
@@ -770,6 +851,9 @@
     "name:tat_x_preferred":[
         "\u0422\u0443\u043d\u0438\u0441"
     ],
+    "name:tay_x_preferred":[
+        "Tunisia"
+    ],
     "name:tel_x_preferred":[
         "\u0c1f\u0c4d\u0c2f\u0c41\u0c28\u0c40\u0c37\u0c3f\u0c2f\u0c3e"
     ],
@@ -794,8 +878,17 @@
     "name:tir_x_variant":[
         "\u1271\u1292\u12da\u12eb"
     ],
+    "name:tok_x_preferred":[
+        "ma Tunisi"
+    ],
     "name:ton_x_preferred":[
         "Tun\u012bsia"
+    ],
+    "name:trv_x_preferred":[
+        "Tunisia"
+    ],
+    "name:tsn_x_preferred":[
+        "Tunisia"
     ],
     "name:tso_x_preferred":[
         "Tunisia"
@@ -837,6 +930,9 @@
     ],
     "name:vec_x_preferred":[
         "Tunixia"
+    ],
+    "name:vec_x_variant":[
+        "Tunizia"
     ],
     "name:vep_x_preferred":[
         "Tunis"
@@ -1134,7 +1230,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1617827406,
+    "wof:lastmodified":1690874838,
     "wof:name":"Tunisia",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/790/95/85679095.geojson
+++ b/data/856/790/95/85679095.geojson
@@ -78,8 +78,17 @@
     "name:fra_x_variant":[
         "gouvernorat de Tozeur"
     ],
+    "name:frr_x_preferred":[
+        "Tozeur"
+    ],
+    "name:gle_x_preferred":[
+        "Tozeur"
+    ],
     "name:guj_x_preferred":[
         "\u0a9f\u0acb\u0a9d\u0ac1\u0ab0 \u0a97\u0ab5\u0ab0\u0acd\u0aa8\u0acb\u0ab0\u0ac7\u0a9f"
+    ],
+    "name:heb_x_preferred":[
+        "\u05d8\u05d5\u05d6\u05d5\u05e8"
     ],
     "name:hin_x_preferred":[
         "\u0924\u094b\u091c\u093c\u093f\u0909\u0930 \u0917\u0935\u0930\u094d\u0928\u0930\u0947\u091f"
@@ -98,6 +107,9 @@
     ],
     "name:kor_x_preferred":[
         "\ud1a0\uc8c4\ub974 \uc8fc"
+    ],
+    "name:kor_x_variant":[
+        "\ud1a0\uc8c4\ub974\uc8fc"
     ],
     "name:lav_x_preferred":[
         "Tauz\u0101ras vil\u0101ja"
@@ -150,6 +162,9 @@
     "name:tha_x_preferred":[
         "\u0e42\u0e17\u0e40\u0e0b\u0e2d\u0e23\u0e4c \u0e42\u0e01\u0e40\u0e27\u0e2d\u0e42\u0e19\u0e40\u0e23\u0e17"
     ],
+    "name:tha_x_variant":[
+        "\u0e40\u0e02\u0e15\u0e1c\u0e39\u0e49\u0e27\u0e48\u0e32\u0e01\u0e32\u0e23\u0e40\u0e15\u0e32\u0e0b\u0e31\u0e23"
+    ],
     "name:tur_x_preferred":[
         "Tuzer ili"
     ],
@@ -170,6 +185,9 @@
     ],
     "name:zho_x_preferred":[
         "\u6258\u6fa4\u723e\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Tozeur Governorate"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"TUN",
@@ -296,7 +314,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1636495667,
+    "wof:lastmodified":1690874830,
     "wof:name":"Tozeur",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/790/99/85679099.geojson
+++ b/data/856/790/99/85679099.geojson
@@ -99,6 +99,12 @@
         "Manouba",
         "gouvernorat de la Manouba"
     ],
+    "name:frr_x_preferred":[
+        "Manouba"
+    ],
+    "name:gle_x_preferred":[
+        "Manouba"
+    ],
     "name:guj_x_preferred":[
         "\u0aae\u0abe\u0aa8\u0acc\u0aac\u0abe \u0a97\u0ab5\u0ab0\u0acd\u0aa8\u0acb\u0ab0\u0ac7\u0a9f"
     ],
@@ -131,7 +137,8 @@
         "\ub9c8\ub204\ubc14"
     ],
     "name:kor_x_variant":[
-        "\ub9c8\ub204\ubc14 \uc8fc"
+        "\ub9c8\ub204\ubc14 \uc8fc",
+        "\ub9c8\ub204\ubc14\uc8fc"
     ],
     "name:lav_x_preferred":[
         "Man\u016bbas vil\u0101ja"
@@ -190,6 +197,9 @@
     "name:tha_x_preferred":[
         "\u0e21\u0e32\u0e19\u0e39\u0e27\u0e1a\u0e32"
     ],
+    "name:tha_x_variant":[
+        "\u0e40\u0e02\u0e15\u0e1c\u0e39\u0e49\u0e27\u0e48\u0e32\u0e01\u0e32\u0e23\u0e21\u0e31\u0e19\u0e19\u0e39\u0e1a\u0e30\u0e2e\u0e4c"
+    ],
     "name:tur_x_preferred":[
         "Manuba"
     ],
@@ -213,6 +223,9 @@
     ],
     "name:zho_x_variant":[
         "\u99ac\u52aa\u5df4\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Manouba Governorate"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"TUN",
@@ -339,7 +352,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1636495667,
+    "wof:lastmodified":1690874831,
     "wof:name":"Manubah",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/791/03/85679103.geojson
+++ b/data/856/791/03/85679103.geojson
@@ -33,7 +33,8 @@
         "\u0628\u0627\u062c\u0629"
     ],
     "name:ara_x_variant":[
-        "Bajah"
+        "Bajah",
+        "\u0648\u0644\u0627\u064a\u0629 \u0628\u0627\u062c\u0629"
     ],
     "name:aze_x_preferred":[
         "Beca vilay\u0259ti"
@@ -69,7 +70,8 @@
         "B\u00e9ja"
     ],
     "name:eng_x_variant":[
-        "Kassrine"
+        "Kassrine",
+        "Beja Governorate"
     ],
     "name:fas_x_preferred":[
         "\u0627\u0633\u062a\u0627\u0646 \u0628\u0627\u062c\u0647"
@@ -85,6 +87,12 @@
     ],
     "name:frr_x_preferred":[
         "B\u00e9ja"
+    ],
+    "name:gle_x_preferred":[
+        "B\u00e9ja"
+    ],
+    "name:heb_x_preferred":[
+        "\u05d1\u05d6'\u05d4"
     ],
     "name:hun_x_preferred":[
         "B\u00e9ja korm\u00e1nyz\u00f3s\u00e1g"
@@ -103,6 +111,9 @@
     ],
     "name:kor_x_preferred":[
         "\ubca0\uc790 \uc8fc"
+    ],
+    "name:kor_x_variant":[
+        "\ubca0\uc790\uc8fc"
     ],
     "name:lit_x_preferred":[
         "Bad\u017eos vilajetas"
@@ -137,6 +148,9 @@
     "name:swe_x_preferred":[
         "B\u00e9ja"
     ],
+    "name:tha_x_preferred":[
+        "\u0e40\u0e02\u0e15\u0e1c\u0e39\u0e49\u0e27\u0e48\u0e32\u0e01\u0e32\u0e23\u0e1a\u0e32\u0e0d\u0e30\u0e2e\u0e4c"
+    ],
     "name:tur_x_preferred":[
         "Bace ili"
     ],
@@ -151,6 +165,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5df4\u5091\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "B\u00e9ja Governorate"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"TUN",
@@ -277,7 +294,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1614896196,
+    "wof:lastmodified":1690874831,
     "wof:name":"B\u00e9ja",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/791/07/85679107.geojson
+++ b/data/856/791/07/85679107.geojson
@@ -67,7 +67,8 @@
         "\u039c\u03c0\u03b9\u03bd \u0391\u03c1\u03bf\u03cd\u03c2"
     ],
     "name:ell_x_variant":[
-        "\u039c\u03c0\u03b5\u03bd \u0391\u03c1\u03bf\u03cd\u03c2"
+        "\u039c\u03c0\u03b5\u03bd \u0391\u03c1\u03bf\u03cd\u03c2",
+        "\u039a\u03c5\u03b2\u03b5\u03c1\u03bd\u03b5\u03af\u03bf \u03c4\u03bf\u03c5 \u039c\u03c0\u03b5\u03bd \u0391\u03c1\u03bf\u03cd\u03c2"
     ],
     "name:eng_x_preferred":[
         "Ben Arous (Tunis Sud)"
@@ -90,8 +91,14 @@
     "name:frr_x_preferred":[
         "Ben Arous"
     ],
+    "name:gle_x_preferred":[
+        "Ben Arous"
+    ],
     "name:guj_x_preferred":[
         "\u0aac\u0ac7\u0aa8 \u0a8f\u0ab0\u0acb\u0ab8 \u0a97\u0ab5\u0ab0\u0acd\u0aa8\u0acb\u0ab0\u0ac7\u0a9f"
+    ],
+    "name:heb_x_preferred":[
+        "\u05d1\u05df \u05e2\u05e8\u05d5\u05e1"
     ],
     "name:hin_x_preferred":[
         "\u092c\u0947\u0928 \u0906\u0930\u0941\u0938 \u0917\u0935\u0930\u094d\u0928\u0930\u0947\u091f"
@@ -156,6 +163,9 @@
     "name:spa_x_preferred":[
         "Gobernaci\u00f3n de Ben Arous"
     ],
+    "name:swa_x_preferred":[
+        "Wilaya ya Ben Arous"
+    ],
     "name:swe_x_preferred":[
         "Ben Arous"
     ],
@@ -185,6 +195,9 @@
     ],
     "name:zho_x_preferred":[
         "\u672c\u963f\u9b6f\u65af\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Ben Arous Governorate"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"TUN",
@@ -311,7 +324,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1614896196,
+    "wof:lastmodified":1690874833,
     "wof:name":"Ben Arous (Tunis Sud)",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/791/13/85679113.geojson
+++ b/data/856/791/13/85679113.geojson
@@ -81,8 +81,17 @@
     "name:fra_x_variant":[
         "gouvernorat de Bizerte"
     ],
+    "name:frr_x_preferred":[
+        "Bizerte"
+    ],
+    "name:gle_x_preferred":[
+        "Bizerte"
+    ],
     "name:guj_x_preferred":[
         "\u0aac\u0abf\u0a9d\u0ac7\u0ab0\u0acd\u0a9f \u0a97\u0ab5\u0ab0\u0acd\u0aa8\u0acb\u0ab0\u0ac7\u0a9f"
+    ],
+    "name:heb_x_preferred":[
+        "\u05d1\u05e0\u05d6\u05e8\u05d8"
     ],
     "name:hin_x_preferred":[
         "\u092c\u093f\u091c\u093c\u0947\u0930\u094d\u0924\u0947 \u0917\u0935\u0930\u094d\u0928\u0930\u0947\u091f"
@@ -107,6 +116,9 @@
     ],
     "name:kor_x_preferred":[
         "\ube44\uc81c\ub974\ud14c \uc8fc"
+    ],
+    "name:kor_x_variant":[
+        "\ube44\uc81c\ub974\ud14c\uc8fc"
     ],
     "name:lav_x_preferred":[
         "Bizertas vil\u0101ja"
@@ -159,6 +171,9 @@
     "name:tha_x_preferred":[
         "\u0e1a\u0e34\u0e40\u0e2a\u0e34\u0e17 \u0e01\u0e2d\u0e1f\u0e40\u0e27\u0e2d\u0e42\u0e19\u0e40\u0e25\u0e17"
     ],
+    "name:tha_x_variant":[
+        "\u0e40\u0e02\u0e15\u0e1c\u0e39\u0e49\u0e27\u0e48\u0e32\u0e01\u0e32\u0e23\u0e1a\u0e31\u0e19\u0e0b\u0e31\u0e23\u0e15\u0e4c"
+    ],
     "name:tur_x_preferred":[
         "Binzert ili"
     ],
@@ -176,6 +191,9 @@
     ],
     "name:zho_x_preferred":[
         "\u6bd4\u585e\u5927\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Bizerte Governorate"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"TUN",
@@ -302,7 +320,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1614896198,
+    "wof:lastmodified":1690874837,
     "wof:name":"Bizerte",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/791/15/85679115.geojson
+++ b/data/856/791/15/85679115.geojson
@@ -81,8 +81,17 @@
     "name:fra_x_variant":[
         "Gouvernorat de Jendouba"
     ],
+    "name:frr_x_preferred":[
+        "Jendouba"
+    ],
+    "name:gle_x_preferred":[
+        "Jendouba"
+    ],
     "name:guj_x_preferred":[
         "\u0a9c\u0ac7\u0a82\u0aa1\u0acb\u0aac\u0abe \u0a97\u0ab5\u0ab0\u0acd\u0aa8\u0acb\u0ab0\u0ac7\u0a9f"
+    ],
+    "name:heb_x_preferred":[
+        "\u05de\u05d7\u05d5\u05d6 \u05d2'\u05e0\u05d3\u05d5\u05d1\u05d4"
     ],
     "name:hin_x_preferred":[
         "\u091c\u0947\u0902\u0921\u0941\u092c\u093e \u0917\u0935\u0930\u094d\u0928\u0930\u0947\u091f"
@@ -101,6 +110,9 @@
     ],
     "name:kor_x_preferred":[
         "\uc820\ub450\ubc14 \uc8fc"
+    ],
+    "name:kor_x_variant":[
+        "\uc820\ub450\ubc14\uc8fc"
     ],
     "name:lav_x_preferred":[
         "D\u017eund\u016bbas vil\u0101ja"
@@ -153,6 +165,9 @@
     "name:tha_x_preferred":[
         "\u0e40\u0e08\u0e19\u0e40\u0e14\u0e32\u0e1a\u0e32 \u0e42\u0e14\u0e40\u0e27\u0e2d\u0e42\u0e19\u0e40\u0e23\u0e17"
     ],
+    "name:tha_x_variant":[
+        "\u0e40\u0e02\u0e15\u0e1c\u0e39\u0e49\u0e27\u0e48\u0e32\u0e01\u0e32\u0e23\u0e0d\u0e31\u0e19\u0e14\u0e39\u0e1a\u0e30\u0e2e\u0e4c"
+    ],
     "name:tur_x_preferred":[
         "Cendube ili"
     ],
@@ -173,6 +188,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5805\u675c\u62dc\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Jendouba Governorate"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"TUN",
@@ -299,7 +317,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1636495669,
+    "wof:lastmodified":1690874836,
     "wof:name":"Jendouba",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/791/19/85679119.geojson
+++ b/data/856/791/19/85679119.geojson
@@ -84,6 +84,12 @@
     "name:fra_x_variant":[
         "Gouvernorat de Nabeul"
     ],
+    "name:frr_x_preferred":[
+        "Nabeul"
+    ],
+    "name:gle_x_preferred":[
+        "Nabeul"
+    ],
     "name:guj_x_preferred":[
         "\u0aa8\u0abe\u0aac\u0ac1\u0ab2 \u0a97\u0ab5\u0ab0\u0acd\u0aa8\u0acb\u0ab0\u0ac7\u0a9f"
     ],
@@ -104,6 +110,9 @@
     ],
     "name:kor_x_preferred":[
         "\ub098\ubd50 \uc8fc"
+    ],
+    "name:kor_x_variant":[
+        "\ub098\ubd50\uc8fc"
     ],
     "name:lav_x_preferred":[
         "N\u0101bulas vil\u0101ja"
@@ -153,8 +162,14 @@
     "name:tel_x_preferred":[
         "\u0c28\u0c3e\u0c2c\u0c3f\u0c2f\u0c32\u0c4d \u0c17\u0c35\u0c30\u0c4d\u0c28\u0c30\u0c47\u0c1f\u0c4d"
     ],
+    "name:tgk_x_preferred":[
+        "\u0432\u0438\u043b\u043e\u044f\u0442\u0438 \u041d\u043e\u0431\u0443\u043b"
+    ],
     "name:tha_x_preferred":[
         "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e19\u0e32\u0e40\u0e1a\u0e34\u0e25"
+    ],
+    "name:tha_x_variant":[
+        "\u0e40\u0e02\u0e15\u0e1c\u0e39\u0e49\u0e27\u0e48\u0e32\u0e01\u0e32\u0e23\u0e19\u0e32\u0e1a\u0e34\u0e25"
     ],
     "name:tur_x_preferred":[
         "Nabil ili"
@@ -176,6 +191,9 @@
     ],
     "name:zho_x_preferred":[
         "\u7d0d\u5e03\u52d2\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Nabeul Governorate"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"TUN",
@@ -302,7 +320,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1636495668,
+    "wof:lastmodified":1690874833,
     "wof:name":"Nabeul",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/791/23/85679123.geojson
+++ b/data/856/791/23/85679123.geojson
@@ -36,6 +36,9 @@
         "\u0648\u0644\u0627\u064a\u0629 \u062a\u0648\u0646\u0633",
         "Tunis"
     ],
+    "name:aze_x_preferred":[
+        "Tunis qubernatorlu\u011fu"
+    ],
     "name:bel_x_preferred":[
         "\u0432\u0456\u043b\u0430\u0435\u0442 \u0422\u0443\u043d\u0456\u0441"
     ],
@@ -48,7 +51,13 @@
     "name:cat_x_preferred":[
         "Governaci\u00f3 de Tunis"
     ],
+    "name:ces_x_preferred":[
+        "Tunisk\u00fd guvernor\u00e1t"
+    ],
     "name:cym_x_preferred":[
+        "Tunis"
+    ],
+    "name:dan_x_preferred":[
         "Tunis"
     ],
     "name:deu_x_preferred":[
@@ -72,6 +81,9 @@
     "name:fra_x_variant":[
         "gouvernorat de Tunis"
     ],
+    "name:gle_x_preferred":[
+        "Tunis"
+    ],
     "name:heb_x_preferred":[
         "\u05ea\u05d5\u05e0\u05d9\u05e1"
     ],
@@ -80,6 +92,9 @@
     ],
     "name:hun_x_preferred":[
         "Tunis"
+    ],
+    "name:hye_x_preferred":[
+        "\u0539\u0578\u0582\u0576\u056b\u057d"
     ],
     "name:ind_x_preferred":[
         "Kegubernuran Tunis"
@@ -97,7 +112,8 @@
         "\ud280\ub2c8\uc2a4"
     ],
     "name:kor_x_variant":[
-        "\ud280\ub2c8\uc2a4 \uc8fc"
+        "\ud280\ub2c8\uc2a4 \uc8fc",
+        "\ud280\ub2c8\uc2a4\uc8fc"
     ],
     "name:msa_x_preferred":[
         "Kawasan kegabenoran Tunis"
@@ -152,6 +168,9 @@
     ],
     "name:zho_x_variant":[
         "\u7a81\u5c3c\u65af\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Tunis Governorate"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"TUN",
@@ -280,7 +299,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1636495669,
+    "wof:lastmodified":1690874836,
     "wof:name":"Tunis",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/791/31/85679131.geojson
+++ b/data/856/791/31/85679131.geojson
@@ -88,8 +88,17 @@
         "gouvernorat du Kef",
         "Kef"
     ],
+    "name:frr_x_preferred":[
+        "Kef"
+    ],
+    "name:gle_x_preferred":[
+        "El Kef"
+    ],
     "name:guj_x_preferred":[
         "\u0a95\u0ac7\u0aab \u0a97\u0ab5\u0ab0\u0acd\u0aa8\u0acb\u0ab0\u0ac7\u0a9f"
+    ],
+    "name:heb_x_preferred":[
+        "\u05de\u05d7\u05d5\u05d6 \u05db\u05e3"
     ],
     "name:hin_x_preferred":[
         "\u0915\u0947\u092b\u093c \u0917\u0935\u0930\u094d\u0928\u0930\u0947\u091f"
@@ -111,6 +120,9 @@
     ],
     "name:kor_x_preferred":[
         "\ucf00\ud504 \uc8fc"
+    ],
+    "name:kor_x_variant":[
+        "\ucf00\ud504\uc8fc"
     ],
     "name:lav_x_preferred":[
         "K\u0101fas vil\u0101ja"
@@ -151,17 +163,26 @@
     "name:spa_x_preferred":[
         "Gobernaci\u00f3n de Al-K\u0101f"
     ],
+    "name:swa_x_preferred":[
+        "Wilaya ya Kef"
+    ],
     "name:swe_x_preferred":[
         "Kef"
     ],
     "name:tam_x_preferred":[
         "\u0b95\u0bc7\u0baa\u0bbf  \u0b95\u0bcb\u0bb5\u0bc6\u0bb0\u0bcd\u0ba9\u0bcb\u0bb0\u0bbe\u0b9f\u0bcd"
     ],
+    "name:tam_x_variant":[
+        "\u0b95\u0bc7\u0baa\u0bbf \u0b95\u0bcb\u0bb5\u0bc6\u0bb0\u0bcd\u0ba9\u0bcb\u0bb0\u0bbe\u0b9f\u0bcd"
+    ],
     "name:tel_x_preferred":[
         "\u0c15\u0c46\u0c2b\u0c4d \u0c17\u0c35\u0c30\u0c4d\u0c28\u0c30\u0c47\u0c1f\u0c4d"
     ],
     "name:tha_x_preferred":[
         "\u0e40\u0e04\u0e1f \u0e01\u0e2d\u0e1f\u0e40\u0e27\u0e2d\u0e42\u0e19\u0e40\u0e25\u0e17"
+    ],
+    "name:tha_x_variant":[
+        "\u0e40\u0e02\u0e15\u0e1c\u0e39\u0e49\u0e27\u0e48\u0e32\u0e01\u0e32\u0e23\u0e2d\u0e31\u0e25\u0e01\u0e32\u0e1f"
     ],
     "name:tur_x_preferred":[
         "K\u00e2f ili"
@@ -180,6 +201,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5361\u592b\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Kef Governorate"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"TUN",
@@ -305,7 +329,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1636495668,
+    "wof:lastmodified":1690874834,
     "wof:name":"Le Kef",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/791/33/85679133.geojson
+++ b/data/856/791/33/85679133.geojson
@@ -81,6 +81,12 @@
     "name:fra_x_variant":[
         "gouvernorat de Kasserine"
     ],
+    "name:frr_x_preferred":[
+        "Kasserine"
+    ],
+    "name:gle_x_preferred":[
+        "Kasserine"
+    ],
     "name:guj_x_preferred":[
         "\u0a95\u0ac7\u0ab8\u0ab0\u0abf\u0aa8 \u0a97\u0ab5\u0ab0\u0acd\u0aa8\u0acb\u0ab0\u0ac7\u0a9f"
     ],
@@ -104,6 +110,9 @@
     ],
     "name:kor_x_preferred":[
         "\uce74\uc138\ub9b0 \uc8fc"
+    ],
+    "name:kor_x_variant":[
+        "\uce74\uc138\ub9b0\uc8fc"
     ],
     "name:lav_x_preferred":[
         "Kasrainas vil\u0101ja"
@@ -156,6 +165,9 @@
     "name:tha_x_preferred":[
         "\u0e40\u0e21\u0e37\u0e2d\u0e07\u0e04\u0e32\u0e0b\u0e31\u0e2a\u0e14\u0e34\u0e19"
     ],
+    "name:tha_x_variant":[
+        "\u0e40\u0e02\u0e15\u0e1c\u0e39\u0e49\u0e27\u0e48\u0e32\u0e01\u0e32\u0e23\u0e2d\u0e31\u0e25\u0e01\u0e47\u0e2d\u0e28\u0e23\u0e35\u0e19"
+    ],
     "name:tur_x_preferred":[
         "Kassarin ili"
     ],
@@ -173,6 +185,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5361\u585e\u6797\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Kasserine Governorate"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"TUN",
@@ -297,7 +312,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1614896196,
+    "wof:lastmodified":1690874832,
     "wof:name":"Kass\u00e9rine",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/791/37/85679137.geojson
+++ b/data/856/791/37/85679137.geojson
@@ -33,7 +33,8 @@
         "\u0642\u0627\u0628\u0633"
     ],
     "name:ara_x_variant":[
-        "Qabis"
+        "Qabis",
+        "\u0648\u0644\u0627\u064a\u0629 \u0642\u0627\u0628\u0633"
     ],
     "name:aze_x_preferred":[
         "Qabes vilay\u0259ti"
@@ -89,8 +90,17 @@
     "name:fra_x_variant":[
         "gouvernorat de Gab\u00e8s"
     ],
+    "name:frr_x_preferred":[
+        "Gab\u00e8s"
+    ],
+    "name:gle_x_preferred":[
+        "Gab\u00e8s"
+    ],
     "name:guj_x_preferred":[
         "\u0a97\u0ac7\u0aac\u0ac7\u0ab8 \u0a97\u0ab5\u0ab0\u0acd\u0aa8\u0acb\u0ab0\u0ac7\u0a9f"
+    ],
+    "name:heb_x_preferred":[
+        "\u05d2\u05d0\u05d1\u05e1"
     ],
     "name:hin_x_preferred":[
         "\u0917\u0947\u092c\u0947\u0938"
@@ -112,6 +122,9 @@
     ],
     "name:kor_x_preferred":[
         "\uac00\ubca0\uc2a4 \uc8fc"
+    ],
+    "name:kor_x_variant":[
+        "\uac00\ubca0\uc2a4\uc8fc"
     ],
     "name:lav_x_preferred":[
         "G\u0101bisas vil\u0101ja"
@@ -164,6 +177,9 @@
     "name:tha_x_preferred":[
         "\u0e40\u0e01\u0e1a\u0e2a\u0e4c"
     ],
+    "name:tha_x_variant":[
+        "\u0e40\u0e02\u0e15\u0e1c\u0e39\u0e49\u0e27\u0e48\u0e32\u0e01\u0e32\u0e23\u0e01\u0e2d\u0e1a\u0e34\u0e2a"
+    ],
     "name:tur_x_preferred":[
         "Gabes"
     ],
@@ -181,6 +197,9 @@
     ],
     "name:zho_x_preferred":[
         "\u52a0\u8c9d\u65af\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Gab\u00e8s Governorate"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"TUN",
@@ -307,7 +326,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1614896197,
+    "wof:lastmodified":1690874835,
     "wof:name":"Gab\u00e8s",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/791/41/85679141.geojson
+++ b/data/856/791/41/85679141.geojson
@@ -85,8 +85,17 @@
         "gouvernorat de Gafsa",
         "Gouvernorat de Gafsa"
     ],
+    "name:frr_x_preferred":[
+        "Gafsa"
+    ],
+    "name:gle_x_preferred":[
+        "Gafsa"
+    ],
     "name:guj_x_preferred":[
         "\u0a97\u0aab\u0acd\u0ab8\u0abe \u0a97\u0ab5\u0ab0\u0acd\u0aa8\u0acb\u0ab0\u0ac7\u0a9f"
+    ],
+    "name:heb_x_preferred":[
+        "\u05d2\u05e4\u05e1\u05d4"
     ],
     "name:hin_x_preferred":[
         "\u0917\u092b\u0938\u093e \u0917\u0935\u0930\u094d\u0928\u0930\u0947\u091f"
@@ -111,6 +120,9 @@
     ],
     "name:kor_x_preferred":[
         "\uac00\ud504\uc0ac \uc8fc"
+    ],
+    "name:kor_x_variant":[
+        "\uac00\ud504\uc0ac\uc8fc"
     ],
     "name:lav_x_preferred":[
         "Gafsas vil\u0101ja"
@@ -163,6 +175,9 @@
     "name:tha_x_preferred":[
         "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e01\u0e32\u0e1f\u0e0b\u0e32"
     ],
+    "name:tha_x_variant":[
+        "\u0e40\u0e02\u0e15\u0e1c\u0e39\u0e49\u0e27\u0e48\u0e32\u0e01\u0e32\u0e23\u0e01\u0e47\u0e2d\u0e1f\u0e40\u0e28\u0e32\u0e30\u0e2e\u0e4c"
+    ],
     "name:tur_x_preferred":[
         "Kafsa ili"
     ],
@@ -183,6 +198,9 @@
     ],
     "name:zho_x_preferred":[
         "\u52a0\u592b\u85a9\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Gafsa Governorate"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"TUN",
@@ -308,7 +326,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1636495669,
+    "wof:lastmodified":1690874835,
     "wof:name":"Gafsa",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/791/47/85679147.geojson
+++ b/data/856/791/47/85679147.geojson
@@ -63,6 +63,9 @@
     "name:ell_x_preferred":[
         "\u03a3\u03af\u03bd\u03c4\u03b9 \u039c\u03c0\u03bf\u03c5 \u0396\u03b1\u03b0\u03bd\u03c4"
     ],
+    "name:ell_x_variant":[
+        "\u039a\u03c5\u03b2\u03b5\u03c1\u03bd\u03b5\u03af\u03bf \u03c4\u03bf\u03c5 \u03a3\u03b9\u03bd\u03c4\u03af \u039c\u03c0\u03bf\u03c5\u03b6\u03af\u03bd\u03c4"
+    ],
     "name:eng_x_preferred":[
         "Sidi Bou Zid"
     ],
@@ -82,8 +85,17 @@
         "Gouvernorat de Sidi Bouzid",
         "Sidi Bouzid"
     ],
+    "name:frr_x_preferred":[
+        "Sidi Bouzid"
+    ],
+    "name:gle_x_preferred":[
+        "Sidi Bouzid"
+    ],
     "name:guj_x_preferred":[
         "\u0ab8\u0abf\u0aa6\u0abf \u0aac\u0acc\u0a9d\u0abf\u0aa6 \u0a97\u0ab5\u0ab0\u0acd\u0aa8\u0acb\u0ab0\u0ac7\u0a9f"
+    ],
+    "name:heb_x_preferred":[
+        "\u05de\u05d7\u05d5\u05d6 \u05e1\u05d9\u05d3\u05d9 \u05d1\u05d5\u05d6\u05d9\u05d3"
     ],
     "name:hin_x_preferred":[
         "\u0938\u093f\u0921\u0940 \u092c\u094c\u091c\u093c\u093f\u0921 \u0917\u0935\u0930\u094d\u0928\u0930\u0947\u091f"
@@ -105,6 +117,9 @@
     ],
     "name:kor_x_preferred":[
         "\uc2dc\ub514\ubd80\uc9c0\ub4dc \uc8fc"
+    ],
+    "name:kor_x_variant":[
+        "\uc2dc\ub514\ubd80\uc9c0\ub4dc\uc8fc"
     ],
     "name:lav_x_preferred":[
         "S\u012bd\u012b B\u016b Zeidas vil\u0101ja"
@@ -145,6 +160,9 @@
     "name:spa_x_preferred":[
         "Gobernaci\u00f3n de Sidi Bouzid"
     ],
+    "name:swa_x_preferred":[
+        "Wilaya ya Sidi Bouzid"
+    ],
     "name:swe_x_preferred":[
         "Sidi Bouzid"
     ],
@@ -156,6 +174,9 @@
     ],
     "name:tha_x_preferred":[
         "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e0b\u0e34\u0e14\u0e34\u0e40\u0e1a\u0e32\u0e0b\u0e34\u0e14"
+    ],
+    "name:tha_x_variant":[
+        "\u0e40\u0e02\u0e15\u0e1c\u0e39\u0e49\u0e27\u0e48\u0e32\u0e01\u0e32\u0e23\u0e0b\u0e35\u0e14\u0e35\u0e1a\u0e39\u0e0b\u0e35\u0e14"
     ],
     "name:tur_x_preferred":[
         "Sidi Bu Zeyd ili"
@@ -174,6 +195,9 @@
     ],
     "name:zho_x_preferred":[
         "\u897f\u8fea\u5e03\u6fdf\u5fb7\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Sidi Bouzid Governorate"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"TUN",
@@ -298,7 +322,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1636495670,
+    "wof:lastmodified":1690874837,
     "wof:name":"Sidi Bou Zid",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/791/51/85679151.geojson
+++ b/data/856/791/51/85679151.geojson
@@ -60,6 +60,9 @@
     "name:deu_x_preferred":[
         "Gouvernorat Sfax"
     ],
+    "name:deu_x_variant":[
+        "Sfax"
+    ],
     "name:ell_x_preferred":[
         "\u03a3\u03c6\u03b1\u03be"
     ],
@@ -83,6 +86,12 @@
     ],
     "name:fra_x_variant":[
         "gouvernorat de Sfax"
+    ],
+    "name:frr_x_preferred":[
+        "Sfax"
+    ],
+    "name:gle_x_preferred":[
+        "Sfax"
     ],
     "name:guj_x_preferred":[
         "\u0ab8\u0acd\u0aab\u0ac7\u0a95\u0acd\u0ab8 \u0a97\u0ab5\u0ab0\u0acd\u0aa8\u0acb\u0ab0\u0ac7\u0a9f"
@@ -110,6 +119,9 @@
     ],
     "name:kor_x_preferred":[
         "\uc2a4\ud30d\uc2a4 \uc8fc"
+    ],
+    "name:kor_x_variant":[
+        "\uc2a4\ud30d\uc2a4\uc8fc"
     ],
     "name:lav_x_preferred":[
         "Sf\u0101ksas vil\u0101ja"
@@ -162,6 +174,9 @@
     "name:tha_x_preferred":[
         "\u0e40\u0e02\u0e15\u0e01\u0e32\u0e23\u0e1b\u0e01\u0e04\u0e23\u0e2d\u0e07\u0e2a\u0e41\u0e1f\u0e01\u0e0b\u0e4c"
     ],
+    "name:tha_x_variant":[
+        "\u0e40\u0e02\u0e15\u0e1c\u0e39\u0e49\u0e27\u0e48\u0e32\u0e01\u0e32\u0e23\u0e2a\u0e1f\u0e31\u0e01\u0e0b\u0e4c"
+    ],
     "name:tur_x_preferred":[
         "Sfaks ili"
     ],
@@ -179,6 +194,9 @@
     ],
     "name:zho_x_preferred":[
         "\u65af\u6cd5\u514b\u65af\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Sfax Governorate"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"TUN",
@@ -305,7 +323,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1636495667,
+    "wof:lastmodified":1690874832,
     "wof:name":"Sfax",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/791/57/85679157.geojson
+++ b/data/856/791/57/85679157.geojson
@@ -78,6 +78,12 @@
     "name:fra_x_variant":[
         "Gouvernorat de Siliana"
     ],
+    "name:frr_x_preferred":[
+        "Siliana"
+    ],
+    "name:gle_x_preferred":[
+        "Siliana"
+    ],
     "name:guj_x_preferred":[
         "\u0ab8\u0abf\u0ab2\u0abf\u0a86\u0aa8\u0abe \u0a97\u0ab5\u0ab0\u0acd\u0aa8\u0acb\u0ab0\u0ac7\u0a9f"
     ],
@@ -98,6 +104,9 @@
     ],
     "name:kor_x_preferred":[
         "\uc2e4\ub9ac\uc544\ub098 \uc8fc"
+    ],
+    "name:kor_x_variant":[
+        "\uc2e4\ub9ac\uc544\ub098\uc8fc"
     ],
     "name:lav_x_preferred":[
         "Silj\u0101nas vil\u0101ja"
@@ -150,6 +159,9 @@
     "name:tha_x_preferred":[
         "\u0e40\u0e02\u0e15\u0e01\u0e32\u0e23\u0e1b\u0e01\u0e04\u0e23\u0e2d\u0e07\u0e0b\u0e34\u0e40\u0e25\u0e35\u0e22\u0e19\u0e32"
     ],
+    "name:tha_x_variant":[
+        "\u0e40\u0e02\u0e15\u0e1c\u0e39\u0e49\u0e27\u0e48\u0e32\u0e01\u0e32\u0e23\u0e0b\u0e34\u0e25\u0e22\u0e32\u0e19\u0e30\u0e2e\u0e4c"
+    ],
     "name:tur_x_preferred":[
         "Silyana ili"
     ],
@@ -170,6 +182,9 @@
     ],
     "name:zho_x_preferred":[
         "\u932b\u52d2\u4e9e\u5948\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Siliana Governorate"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"TUN",
@@ -296,7 +311,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1636495667,
+    "wof:lastmodified":1690874831,
     "wof:name":"Siliana",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/791/61/85679161.geojson
+++ b/data/856/791/61/85679161.geojson
@@ -81,8 +81,17 @@
     "name:fra_x_variant":[
         "gouvernorat de Mahdia"
     ],
+    "name:frr_x_preferred":[
+        "Mahdia"
+    ],
+    "name:gle_x_preferred":[
+        "Mahdia"
+    ],
     "name:guj_x_preferred":[
         "\u0aae\u0ab9\u0aa6\u0abf\u0aaf\u0abe \u0a97\u0ab5\u0ab0\u0acd\u0aa8\u0acb\u0ab0\u0ac7\u0a9f"
+    ],
+    "name:heb_x_preferred":[
+        "\u05de\u05d4\u05d3\u05d9\u05d4"
     ],
     "name:hin_x_preferred":[
         "\u092e\u0939\u0926\u093f\u092f\u093e \u0917\u0935\u0930\u094d\u0928\u0930\u0947\u091f"
@@ -104,6 +113,9 @@
     ],
     "name:kor_x_preferred":[
         "\ub9c8\ub514\uc544 \uc8fc"
+    ],
+    "name:kor_x_variant":[
+        "\ub9c8\ub514\uc544\uc8fc"
     ],
     "name:lav_x_preferred":[
         "Mehd\u012bjas vil\u0101ja"
@@ -156,6 +168,9 @@
     "name:tha_x_preferred":[
         "\u0e40\u0e02\u0e15\u0e01\u0e32\u0e23\u0e1b\u0e01\u0e15\u0e23\u0e2d\u0e07\u0e21\u0e32\u0e2b\u0e4c\u0e40\u0e14\u0e35\u0e22"
     ],
+    "name:tha_x_variant":[
+        "\u0e40\u0e02\u0e15\u0e1c\u0e39\u0e49\u0e27\u0e48\u0e32\u0e01\u0e32\u0e23\u0e2d\u0e31\u0e25\u0e21\u0e30\u0e2e\u0e4c\u0e14\u0e35\u0e22\u0e30\u0e2e\u0e4c"
+    ],
     "name:tur_x_preferred":[
         "Mehdiye ili"
     ],
@@ -173,6 +188,9 @@
     ],
     "name:zho_x_preferred":[
         "\u99ac\u8d6b\u8fea\u8036\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Mahdia Governorate"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"TUN",
@@ -299,7 +317,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1636495667,
+    "wof:lastmodified":1690874831,
     "wof:name":"Mahdia",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/791/65/85679165.geojson
+++ b/data/856/791/65/85679165.geojson
@@ -81,6 +81,12 @@
     "name:fra_x_variant":[
         "Gouvernorat de Monastir"
     ],
+    "name:frr_x_preferred":[
+        "Monastir"
+    ],
+    "name:gle_x_preferred":[
+        "Monastir"
+    ],
     "name:guj_x_preferred":[
         "\u0aae\u0acb\u0aa8\u0abe\u0ab8\u0acd\u0a9f\u0abf\u0ab0 \u0a97\u0ab5\u0ab0\u0acd\u0aa8\u0acb\u0ab0\u0ac7\u0a9f"
     ],
@@ -113,6 +119,9 @@
     ],
     "name:kor_x_preferred":[
         "\ubaa8\ub098\uc2a4\ud2f0\ub974 \uc8fc"
+    ],
+    "name:kor_x_variant":[
+        "\ubaa8\ub098\uc2a4\ud2f0\ub974\uc8fc"
     ],
     "name:lav_x_preferred":[
         "Monast\u012bras vil\u0101ja"
@@ -168,6 +177,9 @@
     "name:tha_x_preferred":[
         "\u0e42\u0e21\u0e19\u0e32\u0e2a\u0e15\u0e35\u0e23\u0e4c"
     ],
+    "name:tha_x_variant":[
+        "\u0e40\u0e02\u0e15\u0e1c\u0e39\u0e49\u0e27\u0e48\u0e32\u0e01\u0e32\u0e23\u0e2d\u0e31\u0e25\u0e21\u0e38\u0e19\u0e31\u0e2a\u0e15\u0e35\u0e23"
+    ],
     "name:tur_x_preferred":[
         "Munast\u0131r"
     ],
@@ -185,6 +197,9 @@
     ],
     "name:zho_x_preferred":[
         "\u83ab\u7d0d\u65af\u63d0\u723e\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Monastir Governorate"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"TUN",
@@ -311,7 +326,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1636495669,
+    "wof:lastmodified":1690874834,
     "wof:name":"Monastir",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/791/71/85679171.geojson
+++ b/data/856/791/71/85679171.geojson
@@ -39,6 +39,9 @@
     "name:aze_x_preferred":[
         "Kayruan vilay\u0259ti"
     ],
+    "name:aze_x_variant":[
+        "Qeyr\u0259van vilay\u0259ti"
+    ],
     "name:bak_x_preferred":[
         "\u041a\u0430\u0440\u0443\u0430\u043d"
     ],
@@ -78,6 +81,12 @@
     "name:fra_x_variant":[
         "Gouvernorat de Kairouan"
     ],
+    "name:frr_x_preferred":[
+        "Kairouan"
+    ],
+    "name:gle_x_preferred":[
+        "Kairouan"
+    ],
     "name:heb_x_preferred":[
         "\u05e7\u05d9\u05e8\u05d5\u05d0\u05df"
     ],
@@ -98,6 +107,9 @@
     ],
     "name:kor_x_preferred":[
         "\uce74\uc774\ub974\uc644 \uc8fc"
+    ],
+    "name:kor_x_variant":[
+        "\uce74\uc774\ub974\uc644\uc8fc"
     ],
     "name:msa_x_preferred":[
         "Kawasan kegabenoran Kairouan"
@@ -129,6 +141,9 @@
     "name:swe_x_preferred":[
         "Kairouan"
     ],
+    "name:tha_x_preferred":[
+        "\u0e40\u0e02\u0e15\u0e1c\u0e39\u0e49\u0e27\u0e48\u0e32\u0e01\u0e32\u0e23\u0e2d\u0e31\u0e25\u0e01\u0e47\u0e2d\u0e22\u0e40\u0e23\u0e32\u0e30\u0e27\u0e32\u0e19"
+    ],
     "name:tur_x_preferred":[
         "Kayravan"
     ],
@@ -141,11 +156,17 @@
     "name:urd_x_preferred":[
         "\u0642\u06cc\u0631\u0648\u0627\u0646"
     ],
+    "name:uzb_x_preferred":[
+        "Qayravon viloyati"
+    ],
     "name:vie_x_preferred":[
         "Kairouan"
     ],
     "name:zho_x_preferred":[
         "\u51f1\u9b6f\u842c\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Kairouan Governorate"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"TUN",
@@ -272,7 +293,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1636495670,
+    "wof:lastmodified":1690874837,
     "wof:name":"Kairouan",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/791/73/85679173.geojson
+++ b/data/856/791/73/85679173.geojson
@@ -78,6 +78,12 @@
     "name:fra_x_variant":[
         "Gouvernorat de Sousse"
     ],
+    "name:frr_x_preferred":[
+        "Sousse"
+    ],
+    "name:gle_x_preferred":[
+        "Sousse"
+    ],
     "name:guj_x_preferred":[
         "\u0ab8\u0acb\u0a82\u0ab8\u0ac7 \u0a97\u0ab5\u0ab0\u0acd\u0aa8\u0acb\u0ab0\u0ac7\u0a9f"
     ],
@@ -107,6 +113,9 @@
     ],
     "name:kor_x_preferred":[
         "\uc218\uc2a4 \uc8fc"
+    ],
+    "name:kor_x_variant":[
+        "\uc218\uc2a4\uc8fc"
     ],
     "name:lav_x_preferred":[
         "S\u016bsas vil\u0101ja"
@@ -159,6 +168,9 @@
     "name:tha_x_preferred":[
         "\u0e0b\u0e39\u0e2a\u0e2a\u0e4c"
     ],
+    "name:tha_x_variant":[
+        "\u0e40\u0e02\u0e15\u0e1c\u0e39\u0e49\u0e27\u0e48\u0e32\u0e01\u0e32\u0e23\u0e0b\u0e39\u0e0b\u0e30\u0e2e\u0e4c"
+    ],
     "name:tur_x_preferred":[
         "Susa ili"
     ],
@@ -176,6 +188,9 @@
     ],
     "name:zho_x_preferred":[
         "\u8607\u585e\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Sousse Governorate"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"TUN",
@@ -302,7 +317,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1636495668,
+    "wof:lastmodified":1690874832,
     "wof:name":"Sousse",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/791/79/85679179.geojson
+++ b/data/856/791/79/85679179.geojson
@@ -78,6 +78,12 @@
     "name:fra_x_variant":[
         "gouvernorat de Zaghouan"
     ],
+    "name:frr_x_preferred":[
+        "Zaghouan"
+    ],
+    "name:gle_x_preferred":[
+        "Zaghouan"
+    ],
     "name:guj_x_preferred":[
         "\u0a9d\u0abe\u0a97\u0acc\u0a86\u0aa8 \u0a97\u0ab5\u0ab0\u0acd\u0aa8\u0acb\u0ab0\u0ac7\u0a9f"
     ],
@@ -98,6 +104,9 @@
     ],
     "name:kor_x_preferred":[
         "\uc790\uad6c\uc644"
+    ],
+    "name:kor_x_variant":[
+        "\uc790\uad6c\uc644\uc8fc"
     ],
     "name:lav_x_preferred":[
         "Zagv\u0101nas vil\u0101ja"
@@ -150,6 +159,9 @@
     "name:tha_x_preferred":[
         "\u0e0b\u0e32\u0e01\u0e27\u0e19"
     ],
+    "name:tha_x_variant":[
+        "\u0e40\u0e02\u0e15\u0e1c\u0e39\u0e49\u0e27\u0e48\u0e32\u0e01\u0e32\u0e23\u0e0b\u0e31\u0e06\u0e27\u0e32\u0e19"
+    ],
     "name:tur_x_preferred":[
         "Za\u011fvan ili"
     ],
@@ -170,6 +182,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5bb0\u683c\u842c\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Zaghouan Governorate"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"TUN",
@@ -296,7 +311,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1636495669,
+    "wof:lastmodified":1690874835,
     "wof:name":"Zaghouan",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/791/83/85679183.geojson
+++ b/data/856/791/83/85679183.geojson
@@ -84,8 +84,17 @@
     "name:fra_x_variant":[
         "Gouvernorat de M\u00e9denine"
     ],
+    "name:frr_x_preferred":[
+        "M\u00e9denine"
+    ],
+    "name:gle_x_preferred":[
+        "M\u00e9denine"
+    ],
     "name:guj_x_preferred":[
         "\u0aae\u0ac7\u0aa1\u0ac7\u0aa8\u0abf\u0aa8 \u0a97\u0ab5\u0ab0\u0acd\u0aa8\u0acb\u0ab0\u0ac7\u0a9f"
+    ],
+    "name:heb_x_preferred":[
+        "\u05de\u05d7\u05d5\u05d6 \u05de\u05d3\u05e0\u05d9\u05df"
     ],
     "name:hin_x_preferred":[
         "\u092e\u0947\u0921\u0947\u0928\u093f\u0928"
@@ -104,6 +113,9 @@
     ],
     "name:kor_x_preferred":[
         "\uba54\ub4dc\ub2cc \uc8fc"
+    ],
+    "name:kor_x_variant":[
+        "\uba54\ub4dc\ub2cc\uc8fc"
     ],
     "name:lav_x_preferred":[
         "Meden\u012bnas vil\u0101ja"
@@ -156,6 +168,9 @@
     "name:tha_x_preferred":[
         "\u0e40\u0e21\u0e40\u0e14\u0e19\u0e35\u0e19"
     ],
+    "name:tha_x_variant":[
+        "\u0e40\u0e02\u0e15\u0e1c\u0e39\u0e49\u0e27\u0e48\u0e32\u0e01\u0e32\u0e23\u0e21\u0e30\u0e14\u0e30\u0e19\u0e35\u0e19"
+    ],
     "name:tur_x_preferred":[
         "Medenin ili"
     ],
@@ -173,6 +188,9 @@
     ],
     "name:zho_x_preferred":[
         "\u6885\u5fb7\u5be7\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Medenine Governorate"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"TUN",
@@ -297,7 +315,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1614896197,
+    "wof:lastmodified":1690874836,
     "wof:name":"M\u00e9denine",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/791/87/85679187.geojson
+++ b/data/856/791/87/85679187.geojson
@@ -85,8 +85,17 @@
         "Gouvernorat de K\u00e9bili",
         "K\u00e9bili"
     ],
+    "name:frr_x_preferred":[
+        "K\u00e9bili"
+    ],
+    "name:gle_x_preferred":[
+        "K\u00e9bili"
+    ],
     "name:guj_x_preferred":[
         "\u0a95\u0ac7\u0aac\u0ac0\u0ab2\u0ac0 \u0a97\u0ab5\u0ab0\u0acd\u0aa8\u0acb\u0ab0\u0ac7\u0a9f"
+    ],
+    "name:heb_x_preferred":[
+        "\u05e7\u05d1\u05d9\u05dc\u05d9"
     ],
     "name:hin_x_preferred":[
         "\u0915\u0947\u092c\u093f\u0932\u0940 \u0917\u0935\u0930\u094d\u0928\u0930\u0947\u091f"
@@ -106,6 +115,9 @@
     "name:kor_x_preferred":[
         "\ucf00\ube4c\ub9ac \uc8fc"
     ],
+    "name:kor_x_variant":[
+        "\ucf00\ube4c\ub9ac\uc8fc"
+    ],
     "name:lav_x_preferred":[
         "Kibil\u012b vil\u0101ja"
     ],
@@ -117,6 +129,9 @@
     ],
     "name:msa_x_preferred":[
         "Kawasan kegabenoran Kebili"
+    ],
+    "name:msa_x_variant":[
+        "Kegabenoran Kebili"
     ],
     "name:nld_x_preferred":[
         "K\u00e9bili"
@@ -157,6 +172,9 @@
     "name:tha_x_preferred":[
         "\u0e40\u0e04\u0e1a\u0e34\u0e25\u0e35"
     ],
+    "name:tha_x_variant":[
+        "\u0e40\u0e02\u0e15\u0e1c\u0e39\u0e49\u0e27\u0e48\u0e32\u0e01\u0e32\u0e23\u0e01\u0e34\u0e1a\u0e34\u0e25\u0e25\u0e35"
+    ],
     "name:tur_x_preferred":[
         "Kabili ili"
     ],
@@ -177,6 +195,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5409\u6bd4\u5229\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Kebili Governorate"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"TUN",
@@ -303,7 +324,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1636495668,
+    "wof:lastmodified":1690874833,
     "wof:name":"Kebili",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/791/91/85679191.geojson
+++ b/data/856/791/91/85679191.geojson
@@ -84,6 +84,12 @@
     "name:fra_x_variant":[
         "Gouvernorat de Tataouine"
     ],
+    "name:frr_x_preferred":[
+        "Tataouine"
+    ],
+    "name:gle_x_preferred":[
+        "Tataouine"
+    ],
     "name:guj_x_preferred":[
         "\u0a9f\u0abe\u0a9f\u0abe\u0a89\u0a87\u0aa8 \u0a97\u0ab5\u0ab0\u0acd\u0aa8\u0acb\u0ab0\u0ac7\u0a9f"
     ],
@@ -104,6 +110,9 @@
     ],
     "name:kor_x_preferred":[
         "\ud0c0\ud0c0\uc6b0\uc778 \uc8fc"
+    ],
+    "name:kor_x_variant":[
+        "\ud0c0\ud0c0\uc6b0\uc778\uc8fc"
     ],
     "name:lav_x_preferred":[
         "Tat\u0101v\u012bnas vil\u0101ja"
@@ -156,6 +165,9 @@
     "name:tha_x_preferred":[
         "\u0e40\u0e02\u0e15\u0e17\u0e32\u0e17\u0e39\u0e2d\u0e34\u0e19"
     ],
+    "name:tha_x_variant":[
+        "\u0e40\u0e02\u0e15\u0e1c\u0e39\u0e49\u0e27\u0e48\u0e32\u0e01\u0e32\u0e23\u0e15\u0e30\u0e0f\u0e2d\u0e27\u0e35\u0e19"
+    ],
     "name:tur_x_preferred":[
         "Tatavin ili"
     ],
@@ -176,6 +188,9 @@
     ],
     "name:zho_x_preferred":[
         "\u6cf0\u5854\u6eab\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Tataouine Governorate"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"TUN",
@@ -302,7 +317,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1636495668,
+    "wof:lastmodified":1690874834,
     "wof:name":"Tataouine",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/890/417/965/890417965.geojson
+++ b/data/890/417/965/890417965.geojson
@@ -55,6 +55,9 @@
     "name:rus_x_preferred":[
         "\u041f\u043e\u0440\u0442 \u042d\u043b\u044c-\u041a\u0430\u043d\u0442\u0430\u0443\u0438"
     ],
+    "name:tur_x_preferred":[
+        "Marsa El-Kantavi"
+    ],
     "name:ukr_x_preferred":[
         "\u041f\u043e\u0440\u0442-\u0435\u043b\u044c-\u041a\u0430\u043d\u0442\u0430\u0443\u0457"
     ],
@@ -91,7 +94,7 @@
         }
     ],
     "wof:id":890417965,
-    "wof:lastmodified":1566667325,
+    "wof:lastmodified":1690874866,
     "wof:name":"Port el Kantaoui",
     "wof:parent_id":1108757689,
     "wof:placetype":"locality",

--- a/data/890/420/455/890420455.geojson
+++ b/data/890/420/455/890420455.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u0645\u0646\u0632\u0644 \u062d\u0631"
     ],
+    "name:cat_x_preferred":[
+        "Menzel Horr"
+    ],
     "name:ceb_x_preferred":[
         "Menzel Heurr"
     ],
@@ -31,14 +34,23 @@
     "name:eng_x_preferred":[
         "Menzel Horr"
     ],
+    "name:fas_x_preferred":[
+        "\u0645\u0646\u0632\u0644 \u062d\u0631"
+    ],
     "name:fra_x_preferred":[
         "Menzel Horr"
+    ],
+    "name:tur_x_preferred":[
+        "Menzil Hur"
     ],
     "name:ukr_x_preferred":[
         "\u041c\u0435\u043d\u0437\u0435\u043b\u044c-\u0425\u043e\u0440\u0440"
     ],
     "name:und_x_variant":[
         "Mennzel Heur"
+    ],
+    "name:zul_x_preferred":[
+        "Menzel Horr"
     ],
     "qs:name":"Menzel Heurr",
     "qs:photos_9r":0,
@@ -71,7 +83,7 @@
         }
     ],
     "wof:id":890420455,
-    "wof:lastmodified":1566667326,
+    "wof:lastmodified":1690874867,
     "wof:name":"Menzel Heurr",
     "wof:parent_id":1108757587,
     "wof:placetype":"locality",

--- a/data/890/434/643/890434643.geojson
+++ b/data/890/434/643/890434643.geojson
@@ -34,6 +34,9 @@
     "name:cym_x_preferred":[
         "Manouba"
     ],
+    "name:dan_x_preferred":[
+        "Manouba"
+    ],
     "name:deu_x_preferred":[
         "Manouba"
     ],
@@ -41,10 +44,14 @@
         "\u039b\u03b1 \u039c\u03b1\u03bd\u03bf\u03c5\u03bc\u03c0\u03ac"
     ],
     "name:ell_x_variant":[
-        "\u039c\u03b1\u03bd\u03bf\u03cd\u03bc\u03c0\u03b1"
+        "\u039c\u03b1\u03bd\u03bf\u03cd\u03bc\u03c0\u03b1",
+        "\u039c\u03b1\u03bd\u03bf\u03c5\u03bc\u03c0\u03ac"
     ],
     "name:eng_x_preferred":[
         "Manouba"
+    ],
+    "name:fas_x_preferred":[
+        "\u0645\u0646\u0648\u0628\u0647"
     ],
     "name:fra_x_preferred":[
         "La Manouba"
@@ -57,6 +64,9 @@
     ],
     "name:ita_x_preferred":[
         "Manouba"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30de\u30cc\u30fc\u30d0"
     ],
     "name:kor_x_preferred":[
         "\ub9c8\ub204\ubc14"
@@ -91,6 +101,9 @@
     "name:swe_x_preferred":[
         "Manouba"
     ],
+    "name:tha_x_preferred":[
+        "\u0e21\u0e31\u0e19\u0e19\u0e39\u0e1a\u0e30\u0e2e\u0e4c"
+    ],
     "name:tur_x_preferred":[
         "Manuba"
     ],
@@ -102,6 +115,9 @@
     ],
     "name:zho_x_preferred":[
         "\u99ac\u52aa\u5df4"
+    ],
+    "name:zul_x_preferred":[
+        "Manouba"
     ],
     "qs:name":"Manouba",
     "qs:photos_9r":0,
@@ -146,7 +162,7 @@
         }
     ],
     "wof:id":890434643,
-    "wof:lastmodified":1566667326,
+    "wof:lastmodified":1690874867,
     "wof:name":"Manouba",
     "wof:parent_id":1108757501,
     "wof:placetype":"locality",

--- a/data/890/434/645/890434645.geojson
+++ b/data/890/434/645/890434645.geojson
@@ -37,17 +37,26 @@
     "name:eng_x_preferred":[
         "Melloul\u00e8che"
     ],
+    "name:fas_x_preferred":[
+        "\u0645\u0644\u0648\u0644\u0634"
+    ],
     "name:fra_x_preferred":[
         "Melloul\u00e8che"
     ],
     "name:ron_x_preferred":[
         "Malloulech"
     ],
+    "name:tur_x_preferred":[
+        "Mellule\u015f"
+    ],
     "name:ukr_x_preferred":[
         "\u041c\u0435\u043b\u043b\u0443\u043b\u0435\u0448"
     ],
     "name:und_x_variant":[
         "Melloun\u00eache"
+    ],
+    "name:zul_x_preferred":[
+        "Melloul\u00e8che"
     ],
     "qs:name":"Melloul\u00e8che",
     "qs:photos_9r":0,
@@ -82,7 +91,7 @@
         }
     ],
     "wof:id":890434645,
-    "wof:lastmodified":1566667326,
+    "wof:lastmodified":1690874868,
     "wof:name":"Melloul\u00e8che",
     "wof:parent_id":1108757483,
     "wof:placetype":"locality",

--- a/data/890/435/459/890435459.geojson
+++ b/data/890/435/459/890435459.geojson
@@ -31,6 +31,9 @@
     "name:ceb_x_preferred":[
         "Oued Lill"
     ],
+    "name:deu_x_preferred":[
+        "Oued Ellil"
+    ],
     "name:eng_x_preferred":[
         "Oued Ellil"
     ],
@@ -43,6 +46,9 @@
     "name:nld_x_preferred":[
         "Oued Ellil"
     ],
+    "name:tur_x_preferred":[
+        "Vadi\u00fc'l-Leyl"
+    ],
     "name:ukr_x_preferred":[
         "\u0423\u0435\u0434-\u0435\u043b\u044c-\u041b\u0456\u043b\u044c"
     ],
@@ -51,6 +57,9 @@
     ],
     "name:urd_x_preferred":[
         "\u0648\u0627\u062f\u06cc \u0627\u0644\u0644\u06cc\u0644"
+    ],
+    "name:zul_x_preferred":[
+        "Oued Ellil"
     ],
     "qs:name":"Oued Lill",
     "qs:photos_9r":0,
@@ -83,7 +92,7 @@
         }
     ],
     "wof:id":890435459,
-    "wof:lastmodified":1566667327,
+    "wof:lastmodified":1690874868,
     "wof:name":"Oued Lill",
     "wof:parent_id":1108757505,
     "wof:placetype":"locality",

--- a/data/890/435/461/890435461.geojson
+++ b/data/890/435/461/890435461.geojson
@@ -34,6 +34,9 @@
     "name:eng_x_preferred":[
         "Sakiet Sidi Youssef"
     ],
+    "name:fas_x_preferred":[
+        "\u0633\u0627\u0642\u06cc\u0647 \u0633\u06cc\u062f\u06cc \u06cc\u0648\u0633\u0641"
+    ],
     "name:fra_x_preferred":[
         "Sakiet Sidi Youssef"
     ],
@@ -43,11 +46,20 @@
     "name:rus_x_preferred":[
         "\u0421\u0430\u043a\u0435\u0442-\u0421\u0438\u0434\u0438-\u042e\u0441\u0435\u0444"
     ],
+    "name:spa_x_preferred":[
+        "Sakiet Sidi Youssef"
+    ],
+    "name:tur_x_preferred":[
+        "Sakiyet Sidi Yusuf"
+    ],
     "name:ukr_x_preferred":[
         "\u0421\u0430\u043a'\u0454\u0442-\u0421\u0456\u0434\u0456-\u042e\u0441\u0441\u0435\u0444"
     ],
     "name:und_x_variant":[
         "Sidi Youssef"
+    ],
+    "name:zul_x_preferred":[
+        "Sakiet Sidi Youssef"
     ],
     "qs:name":"Sakiet Sidi Youssef",
     "qs:photos_9r":0,
@@ -82,7 +94,7 @@
         }
     ],
     "wof:id":890435461,
-    "wof:lastmodified":1566667327,
+    "wof:lastmodified":1690874868,
     "wof:name":"Sakiet Sidi Youssef",
     "wof:parent_id":1108757463,
     "wof:placetype":"locality",

--- a/data/890/435/971/890435971.geojson
+++ b/data/890/435/971/890435971.geojson
@@ -25,6 +25,12 @@
     "name:ara_x_variant":[
         "\u0633\u064a\u062f\u064a \u0628\u0648\u0633\u0639\u064a\u062f"
     ],
+    "name:ast_x_preferred":[
+        "Sidi Bou Said"
+    ],
+    "name:aze_x_preferred":[
+        "Sidi-Bu-Said"
+    ],
     "name:bel_x_preferred":[
         "\u0421\u0456\u0434\u0437\u0456-\u0411\u0443-\u0421\u0430\u0456\u0434"
     ],
@@ -52,6 +58,9 @@
     "name:eng_x_variant":[
         "Sidi Bou Said"
     ],
+    "name:fas_x_preferred":[
+        "\u0633\u06cc\u062f\u06cc \u0628\u0648\u0633\u0639\u06cc\u062f"
+    ],
     "name:fra_x_preferred":[
         "Sidi Bou Sa\u00efd"
     ],
@@ -60,6 +69,9 @@
     ],
     "name:hye_x_preferred":[
         "\u054d\u056b\u0564\u056b \u0532\u0578\u0582 \u054d\u0561\u056b\u0564"
+    ],
+    "name:ind_x_preferred":[
+        "Sidi Bou Said"
     ],
     "name:ita_x_preferred":[
         "Sidi Bou Said"
@@ -72,6 +84,9 @@
     ],
     "name:kor_x_preferred":[
         "\uc2dc\ub514\ubd80\uc0ac\uc774\ub4dc"
+    ],
+    "name:ltz_x_preferred":[
+        "Sidi Bou Sa\u00efd"
     ],
     "name:nld_x_preferred":[
         "Sidi Bou Said"
@@ -97,8 +112,14 @@
     "name:spa_x_preferred":[
         "Sidi Bou Said"
     ],
+    "name:srp_x_preferred":[
+        "\u0421\u0438\u0434\u0438 \u0411\u043e\u0443 \u0421\u0430\u0438\u0434"
+    ],
     "name:swe_x_preferred":[
         "Sidi Bou Said"
+    ],
+    "name:tgk_x_preferred":[
+        "\u0421\u0438\u0434\u0438 \u0411\u0443 \u0421\u0430\u0438\u0434"
     ],
     "name:tur_x_preferred":[
         "Sidi Bu Said"
@@ -114,6 +135,9 @@
     ],
     "name:zho_x_preferred":[
         "\u897f\u8fea\u5e03\u8d5b\u4e49\u5fb7"
+    ],
+    "name:zul_x_preferred":[
+        "Sidi Bou Said"
     ],
     "qs:name":"Sidi Bou Sa\u00efd",
     "qs:photos_9r":0,
@@ -148,7 +172,7 @@
         }
     ],
     "wof:id":890435971,
-    "wof:lastmodified":1566667327,
+    "wof:lastmodified":1690874868,
     "wof:name":"Sidi Bou Sa\u00efd",
     "wof:parent_id":1108757755,
     "wof:placetype":"locality",

--- a/data/890/436/775/890436775.geojson
+++ b/data/890/436/775/890436775.geojson
@@ -31,14 +31,23 @@
     "name:eng_x_preferred":[
         "El Battan"
     ],
+    "name:fas_x_preferred":[
+        "\u0627\u0644\u0628\u0637\u0627\u0646"
+    ],
     "name:fra_x_preferred":[
         "El Batan"
+    ],
+    "name:tur_x_preferred":[
+        "El-Batan"
     ],
     "name:ukr_x_preferred":[
         "\u0415\u043b\u044c-\u0411\u0430\u0442\u0442\u0430\u043d"
     ],
     "name:und_x_variant":[
         "Al Ba\u0163\u0101n"
+    ],
+    "name:zul_x_preferred":[
+        "El Battan"
     ],
     "qs:name":"El Battan",
     "qs:photos_9r":0,
@@ -73,7 +82,7 @@
         }
     ],
     "wof:id":890436775,
-    "wof:lastmodified":1566667324,
+    "wof:lastmodified":1690874865,
     "wof:name":"El Battan",
     "wof:parent_id":1108757497,
     "wof:placetype":"locality",

--- a/data/890/436/899/890436899.geojson
+++ b/data/890/436/899/890436899.geojson
@@ -37,6 +37,9 @@
     "name:eng_x_preferred":[
         "Akouda"
     ],
+    "name:fas_x_preferred":[
+        "\u0627\u06a9\u0648\u062f\u0647"
+    ],
     "name:fra_x_preferred":[
         "Akouda"
     ],
@@ -49,11 +52,17 @@
     "name:ron_x_preferred":[
         "Akouda"
     ],
+    "name:tur_x_preferred":[
+        "Akuda"
+    ],
     "name:ukr_x_preferred":[
         "\u0410\u043a\u0443\u0434\u0430"
     ],
     "name:und_x_variant":[
         "Akuda"
+    ],
+    "name:zul_x_preferred":[
+        "Akouda"
     ],
     "qs:name":"Akouda",
     "qs:photos_9r":0,
@@ -88,7 +97,7 @@
         }
     ],
     "wof:id":890436899,
-    "wof:lastmodified":1566667324,
+    "wof:lastmodified":1690874865,
     "wof:name":"Akouda",
     "wof:parent_id":1108757683,
     "wof:placetype":"locality",

--- a/data/890/438/295/890438295.geojson
+++ b/data/890/438/295/890438295.geojson
@@ -34,6 +34,9 @@
     "name:eng_x_preferred":[
         "Hergla"
     ],
+    "name:fas_x_preferred":[
+        "\u0647\u0631\u0642\u0644\u0647"
+    ],
     "name:fra_x_preferred":[
         "Hergla"
     ],
@@ -49,8 +52,17 @@
     "name:ron_x_preferred":[
         "Hergla"
     ],
+    "name:swa_x_preferred":[
+        "Hergla"
+    ],
+    "name:tur_x_preferred":[
+        "Herkale"
+    ],
     "name:ukr_x_preferred":[
         "\u0413\u0435\u0440\u043a\u043b\u0430"
+    ],
+    "name:zul_x_preferred":[
+        "Hergla"
     ],
     "qs:name":"Harqalah",
     "qs:photos_9r":0,
@@ -83,7 +95,7 @@
         }
     ],
     "wof:id":890438295,
-    "wof:lastmodified":1566667325,
+    "wof:lastmodified":1690874865,
     "wof:name":"Harqalah",
     "wof:parent_id":1108757693,
     "wof:placetype":"locality",

--- a/data/890/438/303/890438303.geojson
+++ b/data/890/438/303/890438303.geojson
@@ -34,6 +34,9 @@
     "name:eng_x_preferred":[
         "Bou Arada"
     ],
+    "name:fas_x_preferred":[
+        "\u0628\u0648\u0639\u0631\u0627\u062f\u0647"
+    ],
     "name:fra_x_preferred":[
         "Bou Arada"
     ],
@@ -43,8 +46,17 @@
     "name:nld_x_preferred":[
         "Bou Arada"
     ],
+    "name:rus_x_preferred":[
+        "\u0411\u0443-\u0410\u0440\u0430\u0434\u0430"
+    ],
+    "name:tur_x_preferred":[
+        "Bu Arada"
+    ],
     "name:ukr_x_preferred":[
         "\u0411\u0443-\u0410\u0440\u0430\u0434\u0430"
+    ],
+    "name:zul_x_preferred":[
+        "Bou Arada"
     ],
     "qs:name":"B\u016b \u2018Ar\u0101dah",
     "qs:photos_9r":0,
@@ -77,7 +89,7 @@
         }
     ],
     "wof:id":890438303,
-    "wof:lastmodified":1566667325,
+    "wof:lastmodified":1690874866,
     "wof:name":"B\u016b \u2018Ar\u0101dah",
     "wof:parent_id":1108757661,
     "wof:placetype":"locality",

--- a/data/890/438/305/890438305.geojson
+++ b/data/890/438/305/890438305.geojson
@@ -28,8 +28,17 @@
     "name:ceb_x_preferred":[
         "Beni Khiar"
     ],
+    "name:deu_x_preferred":[
+        "B\u00e9ni Khiar"
+    ],
+    "name:ell_x_preferred":[
+        "\u039c\u03c0\u03b5\u03bd\u03af \u03a7\u03b9\u03ac\u03c1"
+    ],
     "name:eng_x_preferred":[
         "B\u00e9ni Khiar"
+    ],
+    "name:fas_x_preferred":[
+        "\u0628\u0646\u06cc \u062e\u06cc\u0627\u0631"
     ],
     "name:fra_x_preferred":[
         "B\u00e9ni Khiar"
@@ -40,11 +49,17 @@
     "name:nld_x_preferred":[
         "B\u00e9ni Khiar"
     ],
+    "name:tur_x_preferred":[
+        "Beni H\u0131yar"
+    ],
     "name:ukr_x_preferred":[
         "\u0411\u0435\u043d\u0456-\u0425'\u044f\u0440"
     ],
     "name:und_x_variant":[
         "Ban\u012b Khiy\u0101r"
+    ],
+    "name:zul_x_preferred":[
+        "B\u00e9ni Khiar"
     ],
     "qs:name":"Beni Khiar",
     "qs:photos_9r":0,
@@ -79,7 +94,7 @@
         }
     ],
     "wof:id":890438305,
-    "wof:lastmodified":1566667325,
+    "wof:lastmodified":1690874866,
     "wof:name":"Beni Khiar",
     "wof:parent_id":1108757563,
     "wof:placetype":"locality",

--- a/data/890/440/307/890440307.geojson
+++ b/data/890/440/307/890440307.geojson
@@ -25,17 +25,38 @@
     "name:cat_x_preferred":[
         "Es Sers"
     ],
+    "name:ceb_x_preferred":[
+        "As Sars"
+    ],
+    "name:deu_x_preferred":[
+        "Sers"
+    ],
     "name:eng_x_preferred":[
         "Sers"
+    ],
+    "name:fas_x_preferred":[
+        "\u0627\u0644\u0633\u0631\u0633"
     ],
     "name:fra_x_preferred":[
         "Le Sers"
     ],
+    "name:jpn_x_preferred":[
+        "\u30bb\u30eb\u30b9"
+    ],
     "name:nld_x_preferred":[
+        "Sers"
+    ],
+    "name:por_x_preferred":[
+        "Sers"
+    ],
+    "name:tur_x_preferred":[
         "Sers"
     ],
     "name:ukr_x_preferred":[
         "\u0421\u0435\u0440\u0441"
+    ],
+    "name:zul_x_preferred":[
+        "Sers"
     ],
     "qs:name":"As Sars",
     "qs:photos_9r":0,
@@ -70,7 +91,7 @@
         }
     ],
     "wof:id":890440307,
-    "wof:lastmodified":1566667324,
+    "wof:lastmodified":1690874864,
     "wof:name":"As Sars",
     "wof:parent_id":1108757447,
     "wof:placetype":"locality",

--- a/data/890/441/437/890441437.geojson
+++ b/data/890/441/437/890441437.geojson
@@ -25,8 +25,14 @@
     "name:ara_x_variant":[
         "\u0642\u0641\u0635\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0642\u0641\u0635\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u0642\u0641\u0635\u0647"
+    ],
+    "name:bel_x_preferred":[
+        "\u0413\u0430\u0444\u0441\u0430"
     ],
     "name:ben_x_preferred":[
         "\u0997\u09be\u09ab\u09b8\u09be"
@@ -35,6 +41,9 @@
         "Gafsa"
     ],
     "name:ceb_x_preferred":[
+        "Gafsa"
+    ],
+    "name:ces_x_preferred":[
         "Gafsa"
     ],
     "name:cym_x_preferred":[
@@ -103,6 +112,9 @@
     "name:nld_x_preferred":[
         "Gafsa"
     ],
+    "name:nob_x_preferred":[
+        "Gafsa"
+    ],
     "name:pol_x_preferred":[
         "Kafsa"
     ],
@@ -121,6 +133,12 @@
     "name:slv_x_preferred":[
         "Gafsa"
     ],
+    "name:spa_x_preferred":[
+        "Gafsa"
+    ],
+    "name:swa_x_preferred":[
+        "Gafsa"
+    ],
     "name:swe_x_preferred":[
         "Gafsa"
     ],
@@ -129,6 +147,9 @@
     ],
     "name:tha_x_preferred":[
         "\u0e01\u0e31\u0e1f\u0e0b\u0e32"
+    ],
+    "name:tha_x_variant":[
+        "\u0e01\u0e47\u0e2d\u0e1f\u0e40\u0e28\u0e32\u0e30\u0e2e\u0e4c"
     ],
     "name:tur_x_preferred":[
         "Kafsa"
@@ -147,6 +168,9 @@
     ],
     "name:zho_x_preferred":[
         "\u52a0\u592b\u85a9"
+    ],
+    "name:zul_x_preferred":[
+        "Gafsa"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Tunisia",
@@ -275,7 +299,7 @@
         }
     ],
     "wof:id":890441437,
-    "wof:lastmodified":1636495672,
+    "wof:lastmodified":1690874865,
     "wof:name":"Gafsa",
     "wof:parent_id":1108757335,
     "wof:placetype":"locality",

--- a/data/890/444/461/890444461.geojson
+++ b/data/890/444/461/890444461.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u0633\u0648\u0633\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0633\u0648\u0633\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u0633\u0648\u0633\u0647"
     ],
@@ -54,6 +57,9 @@
     ],
     "name:ces_x_preferred":[
         "S\u00fasa"
+    ],
+    "name:cos_x_preferred":[
+        "Susa"
     ],
     "name:cym_x_preferred":[
         "Sousse"
@@ -115,6 +121,9 @@
     "name:hye_x_preferred":[
         "\u054d\u0578\u0582\u057d"
     ],
+    "name:ido_x_preferred":[
+        "Sousse"
+    ],
     "name:ile_x_preferred":[
         "Sousse"
     ],
@@ -154,6 +163,9 @@
     "name:mar_x_preferred":[
         "\u0938\u0949\u0938"
     ],
+    "name:mlt_x_preferred":[
+        "Sousse"
+    ],
     "name:msa_x_preferred":[
         "Sousse"
     ],
@@ -168,6 +180,9 @@
     ],
     "name:nor_x_preferred":[
         "Sousse"
+    ],
+    "name:oss_x_preferred":[
+        "\u0421\u0443\u0441"
     ],
     "name:pol_x_preferred":[
         "Susa"
@@ -205,8 +220,14 @@
     "name:srp_x_preferred":[
         "\u0421\u0443\u0441"
     ],
+    "name:swa_x_preferred":[
+        "Sousse"
+    ],
     "name:swe_x_preferred":[
         "Sousse"
+    ],
+    "name:szl_x_preferred":[
+        "Susa"
     ],
     "name:tam_x_preferred":[
         "\u0b9a\u0bcc\u0bb8\u0bcd\u0bb8\u0bc7"
@@ -217,6 +238,9 @@
     "name:tha_x_preferred":[
         "\u0e0b\u0e39\u0e2a\u0e2a\u0e4c\u0e0b\u0e35"
     ],
+    "name:tha_x_variant":[
+        "\u0e0b\u0e39\u0e0b\u0e30\u0e2e\u0e4c"
+    ],
     "name:tur_x_preferred":[
         "Susa"
     ],
@@ -226,6 +250,9 @@
     "name:urd_x_preferred":[
         "\u0633\u0648\u0633\u06c1"
     ],
+    "name:uzb_x_preferred":[
+        "Sus"
+    ],
     "name:vie_x_preferred":[
         "Sousse"
     ],
@@ -234,6 +261,9 @@
     ],
     "name:zho_x_preferred":[
         "\u82cf\u585e"
+    ],
+    "name:zul_x_preferred":[
+        "Sousse"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Tunisia",
@@ -362,7 +392,7 @@
         }
     ],
     "wof:id":890444461,
-    "wof:lastmodified":1636495673,
+    "wof:lastmodified":1690874867,
     "wof:name":"Sousse",
     "wof:parent_id":1108757713,
     "wof:placetype":"locality",

--- a/data/890/444/463/890444463.geojson
+++ b/data/890/444/463/890444463.geojson
@@ -34,8 +34,17 @@
     "name:eng_x_preferred":[
         "Testour"
     ],
+    "name:epo_x_preferred":[
+        "Testur"
+    ],
+    "name:fas_x_preferred":[
+        "\u062a\u0633\u062a\u0648\u0631"
+    ],
     "name:fra_x_preferred":[
         "Testour"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30c1\u30e5\u30cb\u30b8\u30a2"
     ],
     "name:ltz_x_preferred":[
         "Testour"
@@ -49,8 +58,20 @@
     "name:rus_x_preferred":[
         "\u0422\u0435\u0441\u0442\u0443\u0440"
     ],
+    "name:spa_x_preferred":[
+        "Testour"
+    ],
+    "name:tur_x_preferred":[
+        "Testur"
+    ],
     "name:ukr_x_preferred":[
         "\u0422\u0435\u0441\u0442\u0443\u0440"
+    ],
+    "name:urd_x_preferred":[
+        "\u062a\u0633\u062a\u0648\u0631"
+    ],
+    "name:zul_x_preferred":[
+        "Testour"
     ],
     "qs:name":"Tast\u016br",
     "qs:photos_9r":0,
@@ -83,7 +104,7 @@
         }
     ],
     "wof:id":890444463,
-    "wof:lastmodified":1566667325,
+    "wof:lastmodified":1690874866,
     "wof:name":"Tast\u016br",
     "wof:parent_id":1108757267,
     "wof:placetype":"locality",

--- a/data/890/444/465/890444465.geojson
+++ b/data/890/444/465/890444465.geojson
@@ -22,8 +22,17 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0642\u0644\u0639\u0629"
     ],
+    "name:cat_x_preferred":[
+        "El Gol\u00e2a"
+    ],
+    "name:ceb_x_preferred":[
+        "El Golaa"
+    ],
     "name:eng_x_preferred":[
         "El Gol\u00e2a"
+    ],
+    "name:fas_x_preferred":[
+        "\u0627\u0644\u0642\u0644\u0639\u0647"
     ],
     "name:fra_x_preferred":[
         "El Gol\u00e2a"
@@ -37,11 +46,17 @@
     "name:sco_x_preferred":[
         "El Gol\u00e2a"
     ],
+    "name:tur_x_preferred":[
+        "El-Kale"
+    ],
     "name:ukr_x_preferred":[
         "\u0415\u043b\u044c-\u041a\u0430\u043b\u044f\u0430"
     ],
     "name:und_x_variant":[
         "Galaa"
+    ],
+    "name:zul_x_preferred":[
+        "El Gol\u00e2a"
     ],
     "qs:name":"El Golaa",
     "qs:photos_9r":0,
@@ -76,7 +91,7 @@
         }
     ],
     "wof:id":890444465,
-    "wof:lastmodified":1566667326,
+    "wof:lastmodified":1690874866,
     "wof:name":"El Golaa",
     "wof:parent_id":1108757429,
     "wof:placetype":"locality",

--- a/data/890/444/467/890444467.geojson
+++ b/data/890/444/467/890444467.geojson
@@ -28,11 +28,20 @@
     "name:ceb_x_preferred":[
         "La Mohammedia"
     ],
+    "name:deu_x_preferred":[
+        "Mohamedia"
+    ],
     "name:eng_x_preferred":[
         "Mohamedia"
     ],
     "name:fra_x_preferred":[
         "Mohamedia"
+    ],
+    "name:rus_x_preferred":[
+        "\u042d\u043b\u044c-\u041c\u0443\u0445\u0430\u043c\u043c\u0435\u0434\u0438\u044f"
+    ],
+    "name:tur_x_preferred":[
+        "Muhammediye"
     ],
     "name:ukr_x_preferred":[
         "\u041c\u043e\u0445\u0430\u043c\u0435\u0434\u0456\u044f"
@@ -71,7 +80,7 @@
         }
     ],
     "wof:id":890444467,
-    "wof:lastmodified":1566667326,
+    "wof:lastmodified":1690874867,
     "wof:name":"La Mohammedia",
     "wof:parent_id":1108757271,
     "wof:placetype":"locality",

--- a/data/890/455/413/890455413.geojson
+++ b/data/890/455/413/890455413.geojson
@@ -31,6 +31,9 @@
     "name:eng_x_preferred":[
         "El Ksour"
     ],
+    "name:fas_x_preferred":[
+        "\u0627\u0644\u0642\u0635\u0648\u0631"
+    ],
     "name:fra_x_preferred":[
         "El Ksour"
     ],
@@ -40,11 +43,17 @@
     "name:nld_x_preferred":[
         "El Ksour"
     ],
+    "name:tur_x_preferred":[
+        "El-Kusur"
+    ],
     "name:ukr_x_preferred":[
         "\u0415\u043b\u044c-\u041a\u0441\u0443\u0440"
     ],
     "name:und_x_variant":[
         "Al Qu\u015f\u016br"
+    ],
+    "name:zul_x_preferred":[
+        "El Ksour"
     ],
     "qs:name":"El Ksour",
     "qs:photos_9r":0,
@@ -79,7 +88,7 @@
         }
     ],
     "wof:id":890455413,
-    "wof:lastmodified":1566667324,
+    "wof:lastmodified":1690874865,
     "wof:name":"El Ksour",
     "wof:parent_id":1108757445,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.