### PR TITLE
tn concordances, placetype local, and more

### DIFF
--- a/data/110/875/723/9/1108757239.geojson
+++ b/data/110/875/723/9/1108757239.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.032725,
-    "geom:area_square_m":323305635.355338,
+    "geom:area_square_m":323305559.657743,
     "geom:bbox":"9.973696,36.835079,10.242028,37.116491",
     "geom:latitude":36.967562,
     "geom:longitude":10.103995,
@@ -87,9 +87,10 @@
     "wof:concordances":{
         "hasc:id":"TN.AN.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307106,
-    "wof:geomhash":"9879618cf5d33ea3eb41b4cbae76be39",
+    "wof:geomhash":"c2eb0a15abb37471e5bd55fc3dfd77e7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":1108757239,
-    "wof:lastmodified":1627522824,
+    "wof:lastmodified":1695886529,
     "wof:name":"Ariana",
     "wof:parent_id":1108807159,
     "wof:placetype":"county",

--- a/data/110/875/724/3/1108757243.geojson
+++ b/data/110/875/724/3/1108757243.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001446,
-    "geom:area_square_m":14303715.108528,
+    "geom:area_square_m":14303800.647006,
     "geom:bbox":"10.146916,36.847399,10.207095,36.885139",
     "geom:latitude":36.863198,
     "geom:longitude":10.17055,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.AN.AR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307107,
-    "wof:geomhash":"32099f41352764a6057d5f934273b7c7",
+    "wof:geomhash":"f041b37111ecce22ab6eaa15935f9b7c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757243,
-    "wof:lastmodified":1627522824,
+    "wof:lastmodified":1695886529,
     "wof:name":"Ariana Elmadina",
     "wof:parent_id":1108807159,
     "wof:placetype":"county",

--- a/data/110/875/724/5/1108757245.geojson
+++ b/data/110/875/724/5/1108757245.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000337,
-    "geom:area_square_m":3336087.14695,
+    "geom:area_square_m":3336159.614885,
     "geom:bbox":"10.094038,36.817226,10.120074,36.836509",
     "geom:latitude":36.827924,
     "geom:longitude":10.108618,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.AN.ET"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307108,
-    "wof:geomhash":"158149f132c2b3873522d1bf2a822fc6",
+    "wof:geomhash":"014881c8643f2717b0cdb602e9841771",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757245,
-    "wof:lastmodified":1627522827,
+    "wof:lastmodified":1695886534,
     "wof:name":"Ettadhamen",
     "wof:parent_id":1108807159,
     "wof:placetype":"county",

--- a/data/110/875/724/7/1108757247.geojson
+++ b/data/110/875/724/7/1108757247.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006874,
-    "geom:area_square_m":67949773.099717,
+    "geom:area_square_m":67949613.401548,
     "geom:bbox":"10.12094,36.872499,10.252739,36.982078",
     "geom:latitude":36.92733,
     "geom:longitude":10.181342,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"TN.AN.RA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307109,
-    "wof:geomhash":"5921368a002fdb3bae67eb3d26ed95dc",
+    "wof:geomhash":"e2c4477c94e04ac6ddb1c86e79096a76",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -82,7 +83,7 @@
         }
     ],
     "wof:id":1108757247,
-    "wof:lastmodified":1627522832,
+    "wof:lastmodified":1695886544,
     "wof:name":"Roued",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/110/875/724/9/1108757249.geojson
+++ b/data/110/875/724/9/1108757249.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005558,
-    "geom:area_square_m":54966450.924465,
+    "geom:area_square_m":54966574.857525,
     "geom:bbox":"10.183499,36.85089,10.284072,36.946608",
     "geom:latitude":36.893021,
     "geom:longitude":10.236503,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.AN.LS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307110,
-    "wof:geomhash":"58050c15bedef3a9a735eaadb6a54aa8",
+    "wof:geomhash":"b49e41eb5679f4101876e92a9dc64e26",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757249,
-    "wof:lastmodified":1627522834,
+    "wof:lastmodified":1695886548,
     "wof:name":"Soukra",
     "wof:parent_id":1108807159,
     "wof:placetype":"county",

--- a/data/110/875/725/1/1108757251.geojson
+++ b/data/110/875/725/1/1108757251.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.02397,
-    "geom:area_square_m":237367153.611725,
+    "geom:area_square_m":237367132.016628,
     "geom:bbox":"8.912544,36.659277,9.139058,36.887809",
     "geom:latitude":36.788714,
     "geom:longitude":9.035411,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.BJ.AM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307111,
-    "wof:geomhash":"b3635020a352c63b7e541f4da89d2837",
+    "wof:geomhash":"cb8ba043304dc700867f65277e4ee5cc",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757251,
-    "wof:lastmodified":1627522824,
+    "wof:lastmodified":1695886529,
     "wof:name":"Amdoun",
     "wof:parent_id":85679103,
     "wof:placetype":"county",

--- a/data/110/875/725/3/1108757253.geojson
+++ b/data/110/875/725/3/1108757253.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.042526,
-    "geom:area_square_m":421068873.60749,
+    "geom:area_square_m":421069254.111431,
     "geom:bbox":"9.070448,36.682599,9.381616,36.911313",
     "geom:latitude":36.797285,
     "geom:longitude":9.237654,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.BJ.BN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307113,
-    "wof:geomhash":"d0ea2525525991830694cec6f864e7d4",
+    "wof:geomhash":"646d08304f4c84f2703c009e463c0918",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757253,
-    "wof:lastmodified":1627522824,
+    "wof:lastmodified":1695886530,
     "wof:name":"Beja Nord",
     "wof:parent_id":85679103,
     "wof:placetype":"county",

--- a/data/110/875/725/5/1108757255.geojson
+++ b/data/110/875/725/5/1108757255.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.036497,
-    "geom:area_square_m":362109372.577056,
+    "geom:area_square_m":362109341.175392,
     "geom:bbox":"9.014805,36.531037,9.346866,36.730961",
     "geom:latitude":36.641186,
     "geom:longitude":9.182612,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.BJ.BS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307114,
-    "wof:geomhash":"38b1101121e7f5bb70ed25a94e8deaab",
+    "wof:geomhash":"09b56eba5949c045fbe8c14b64f9fac0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757255,
-    "wof:lastmodified":1627522824,
+    "wof:lastmodified":1695886530,
     "wof:name":"Beja sud",
     "wof:parent_id":85679103,
     "wof:placetype":"county",

--- a/data/110/875/725/7/1108757257.geojson
+++ b/data/110/875/725/7/1108757257.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.04035,
-    "geom:area_square_m":400938429.360744,
+    "geom:area_square_m":400938472.875232,
     "geom:bbox":"9.5382,36.422597,9.864532,36.636757",
     "geom:latitude":36.526149,
     "geom:longitude":9.690854,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.BJ.GO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307115,
-    "wof:geomhash":"a54c5a188b983615410839de254cb1e3",
+    "wof:geomhash":"895754fef7e29e1081edf7a2fbb00070",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757257,
-    "wof:lastmodified":1627522828,
+    "wof:lastmodified":1695886536,
     "wof:name":"Goblat",
     "wof:parent_id":85679103,
     "wof:placetype":"county",

--- a/data/110/875/726/1/1108757261.geojson
+++ b/data/110/875/726/1/1108757261.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.046757,
-    "geom:area_square_m":463588155.321984,
+    "geom:area_square_m":463588345.635594,
     "geom:bbox":"9.429502,36.572192,9.797343,36.835808",
     "geom:latitude":36.694533,
     "geom:longitude":9.617259,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.BJ.MB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307116,
-    "wof:geomhash":"af1da02d9991e0a438cc929162c6f6fc",
+    "wof:geomhash":"191b0987f052536524c9dfdc86b12d57",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757261,
-    "wof:lastmodified":1627522831,
+    "wof:lastmodified":1695886542,
     "wof:name":"Mejez El Bab",
     "wof:parent_id":85679103,
     "wof:placetype":"county",

--- a/data/110/875/726/3/1108757263.geojson
+++ b/data/110/875/726/3/1108757263.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.061241,
-    "geom:area_square_m":604911839.299746,
+    "geom:area_square_m":604911839.299783,
     "geom:bbox":"8.89029520912,36.8232402797,9.24466464133,37.158748627",
     "geom:latitude":36.982666,
     "geom:longitude":9.067895,
@@ -78,9 +78,10 @@
     "wof:concordances":{
         "hasc:id":"TN.BJ.NE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307117,
-    "wof:geomhash":"736aebc385c1278a401acae8559bce43",
+    "wof:geomhash":"baea731c688f1ac4d8af10cfee7c72a3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1108757263,
-    "wof:lastmodified":1566667269,
+    "wof:lastmodified":1695886583,
     "wof:name":"Nefza",
     "wof:parent_id":85679103,
     "wof:placetype":"county",

--- a/data/110/875/726/5/1108757265.geojson
+++ b/data/110/875/726/5/1108757265.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.040056,
-    "geom:area_square_m":398406661.483298,
+    "geom:area_square_m":398406712.440999,
     "geom:bbox":"9.070566,36.333111,9.355789,36.574642",
     "geom:latitude":36.45098,
     "geom:longitude":9.231904,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.BJ.TB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307119,
-    "wof:geomhash":"961c42ce8148641587ba1e569fb5e85f",
+    "wof:geomhash":"d9f284dbb6f3d9fe6382b9f9df6f5af0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757265,
-    "wof:lastmodified":1627522835,
+    "wof:lastmodified":1695886550,
     "wof:name":"Teboursouk",
     "wof:parent_id":85679103,
     "wof:placetype":"county",

--- a/data/110/875/726/7/1108757267.geojson
+++ b/data/110/875/726/7/1108757267.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.065127,
-    "geom:area_square_m":646685814.809047,
+    "geom:area_square_m":646685814.809051,
     "geom:bbox":"9.23126070406,36.4344904763,9.62532980422,36.7327266763",
     "geom:latitude":36.579317,
     "geom:longitude":9.428002,
@@ -87,9 +87,10 @@
     "wof:concordances":{
         "hasc:id":"TN.BJ.TT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307120,
-    "wof:geomhash":"48b3948420fcd92cf6d9776797c510e2",
+    "wof:geomhash":"252de96e6e656d24f99f9f2d214932fc",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":1108757267,
-    "wof:lastmodified":1566667269,
+    "wof:lastmodified":1695886583,
     "wof:name":"Testour",
     "wof:parent_id":85679103,
     "wof:placetype":"county",

--- a/data/110/875/726/9/1108757269.geojson
+++ b/data/110/875/726/9/1108757269.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010943,
-    "geom:area_square_m":108769994.645563,
+    "geom:area_square_m":108769928.673287,
     "geom:bbox":"9.019108,36.439733,9.166189,36.593187",
     "geom:latitude":36.50276,
     "geom:longitude":9.096546,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.BJ.TH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307121,
-    "wof:geomhash":"9152412d850c7b62943ce189c8a07d79",
+    "wof:geomhash":"af89abbe9fd9f770113db0e9086dfea6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757269,
-    "wof:lastmodified":1627522835,
+    "wof:lastmodified":1695886550,
     "wof:name":"Tibar",
     "wof:parent_id":85679103,
     "wof:placetype":"county",

--- a/data/110/875/727/1/1108757271.geojson
+++ b/data/110/875/727/1/1108757271.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.068888,
-    "geom:area_square_m":683571422.805617,
+    "geom:area_square_m":683571422.805583,
     "geom:bbox":"10.0398059444,36.4547378924,10.4078951774,36.812084198",
     "geom:latitude":36.631615,
     "geom:longitude":10.24398,
@@ -129,9 +129,10 @@
     "wof:concordances":{
         "hasc:id":"TN.BA.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307122,
-    "wof:geomhash":"e2760ba9020b219f8dd809721aa5e261",
+    "wof:geomhash":"c489ab2d0c486ba458c316bc94f54dc3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":1108757271,
-    "wof:lastmodified":1566667274,
+    "wof:lastmodified":1695886584,
     "wof:name":"Ben Arous",
     "wof:parent_id":85679107,
     "wof:placetype":"county",

--- a/data/110/875/727/3/1108757273.geojson
+++ b/data/110/875/727/3/1108757273.geojson
@@ -84,9 +84,10 @@
     "wof:concordances":{
         "hasc:id":"TN.BA.EZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307123,
-    "wof:geomhash":"e7d1f48f517973a39b9838403fadc1cf",
+    "wof:geomhash":"5da14ac09d3d6ccdcbb4a36b808a9b1d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":1108757273,
-    "wof:lastmodified":1566667274,
+    "wof:lastmodified":1695886584,
     "wof:name":"Ezzahra",
     "wof:parent_id":85679107,
     "wof:placetype":"county",

--- a/data/110/875/727/5/1108757275.geojson
+++ b/data/110/875/727/5/1108757275.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.057508,
-    "geom:area_square_m":566238858.851849,
+    "geom:area_square_m":566238968.01876,
     "geom:bbox":"9.476904,37.076076,9.859636,37.349556",
     "geom:latitude":37.223314,
     "geom:longitude":9.671004,
@@ -51,9 +51,10 @@
     "wof:concordances":{
         "hasc:id":"TN.BZ.BS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307124,
-    "wof:geomhash":"ee6f42cd1563276c912d99e75fca9547",
+    "wof:geomhash":"2bec8c3563f5b0d250d891608866828e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -63,7 +64,7 @@
         }
     ],
     "wof:id":1108757275,
-    "wof:lastmodified":1627522825,
+    "wof:lastmodified":1695886531,
     "wof:name":"Bierte Sud",
     "wof:parent_id":85679113,
     "wof:placetype":"county",

--- a/data/110/875/727/9/1108757279.geojson
+++ b/data/110/875/727/9/1108757279.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000875,
-    "geom:area_square_m":8577046.083569,
+    "geom:area_square_m":8577046.083566,
     "geom:bbox":"8.901249886,37.512916565,8.962916374,37.542945862",
     "geom:latitude":37.525618,
     "geom:longitude":8.934465,
@@ -193,9 +193,10 @@
     "wof:concordances":{
         "hasc:id":"TN.BZ.BS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307126,
-    "wof:geomhash":"bc8a8dcebea5d80b4f44c2fc81862a26",
+    "wof:geomhash":"01e50c75c9a8e0c45a05f08e6def8acb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -211,7 +212,7 @@
         }
     ],
     "wof:id":1108757279,
-    "wof:lastmodified":1566667274,
+    "wof:lastmodified":1695886584,
     "wof:name":"Bizerte",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/110/875/728/1/1108757281.geojson
+++ b/data/110/875/728/1/1108757281.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005413,
-    "geom:area_square_m":53236853.953919,
+    "geom:area_square_m":53236989.324903,
     "geom:bbox":"9.763709,37.263096,9.882112,37.340416",
     "geom:latitude":37.306121,
     "geom:longitude":9.829561,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.BZ.BN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307127,
-    "wof:geomhash":"829358964cfc6207940eaee978e7525b",
+    "wof:geomhash":"b39310fa4c61e6e115f5e0f99c85da3a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757281,
-    "wof:lastmodified":1627522825,
+    "wof:lastmodified":1695886531,
     "wof:name":"Bizerte Nord",
     "wof:parent_id":85679113,
     "wof:placetype":"county",

--- a/data/110/875/728/3/1108757283.geojson
+++ b/data/110/875/728/3/1108757283.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007601,
-    "geom:area_square_m":74917119.198732,
+    "geom:area_square_m":74917119.198731,
     "geom:bbox":"9.92543654658,37.1004216926,10.0663239179,37.205458804",
     "geom:latitude":37.14878,
     "geom:longitude":9.997469,
@@ -78,9 +78,10 @@
     "wof:concordances":{
         "hasc:id":"TN.BZ.AL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307128,
-    "wof:geomhash":"1169485819ab060e5adb88cbd1c7a2de",
+    "wof:geomhash":"4c005323acd2a854f2aefd949a6e4588",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1108757283,
-    "wof:lastmodified":1566667270,
+    "wof:lastmodified":1695886584,
     "wof:name":"El Alia",
     "wof:parent_id":85679113,
     "wof:placetype":"county",

--- a/data/110/875/728/5/1108757285.geojson
+++ b/data/110/875/728/5/1108757285.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.043997,
-    "geom:area_square_m":434029873.594618,
+    "geom:area_square_m":434029617.116788,
     "geom:bbox":"9.335378,36.951912,9.654717,37.197378",
     "geom:latitude":37.078461,
     "geom:longitude":9.491028,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.BZ.GH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307129,
-    "wof:geomhash":"eae8ebea4bfaa035c538518d570bce69",
+    "wof:geomhash":"a5a1c739e5d8fd48e9e7521449c73d49",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757285,
-    "wof:lastmodified":1627522826,
+    "wof:lastmodified":1695886532,
     "wof:name":"El Gazala",
     "wof:parent_id":85679113,
     "wof:placetype":"county",

--- a/data/110/875/728/7/1108757287.geojson
+++ b/data/110/875/728/7/1108757287.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009956,
-    "geom:area_square_m":98118658.359529,
+    "geom:area_square_m":98118552.977879,
     "geom:bbox":"9.994927,37.086616,10.283778,37.205459",
     "geom:latitude":37.156126,
     "geom:longitude":10.111905,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.BZ.GM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307130,
-    "wof:geomhash":"fa61f0568a5653d9fe9444c9d0dfdcb9",
+    "wof:geomhash":"e2fdf8b6c2892568a6cfc13e811a15f8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757287,
-    "wof:lastmodified":1627522828,
+    "wof:lastmodified":1695886536,
     "wof:name":"Gar El Melh",
     "wof:parent_id":85679113,
     "wof:placetype":"county",

--- a/data/110/875/728/9/1108757289.geojson
+++ b/data/110/875/728/9/1108757289.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000654,
-    "geom:area_square_m":6436401.102,
+    "geom:area_square_m":6436427.743276,
     "geom:bbox":"9.863028,37.245881,9.907529,37.270818",
     "geom:latitude":37.25676,
     "geom:longitude":9.886943,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.BZ.JA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307132,
-    "wof:geomhash":"37c7f464e2a986e6213d16b281b1fffb",
+    "wof:geomhash":"640613de0c840e7ebc4c577ad160316f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757289,
-    "wof:lastmodified":1627522835,
+    "wof:lastmodified":1695886550,
     "wof:name":"Jerzouna",
     "wof:parent_id":85679113,
     "wof:placetype":"county",

--- a/data/110/875/729/1/1108757291.geojson
+++ b/data/110/875/729/1/1108757291.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.055697,
-    "geom:area_square_m":550845194.508441,
+    "geom:area_square_m":550845113.175959,
     "geom:bbox":"9.213181,36.722968,9.585699,37.014097",
     "geom:latitude":36.885836,
     "geom:longitude":9.399773,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.BZ.JO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307133,
-    "wof:geomhash":"7cc12b894ac24248088d4b647a64957d",
+    "wof:geomhash":"79fe2a1512eaec6ad57a8b50c33ccb64",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757291,
-    "wof:lastmodified":1627522829,
+    "wof:lastmodified":1695886538,
     "wof:name":"Joumine",
     "wof:parent_id":85679113,
     "wof:placetype":"county",

--- a/data/110/875/729/3/1108757293.geojson
+++ b/data/110/875/729/3/1108757293.geojson
@@ -87,9 +87,10 @@
     "wof:concordances":{
         "hasc:id":"TN.BZ.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307134,
-    "wof:geomhash":"bc99f75bf6a93f67ec75cba752f0d546",
+    "wof:geomhash":"a5124a0a5d4cf61f04f9228efef969fd",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":1108757293,
-    "wof:lastmodified":1566667274,
+    "wof:lastmodified":1695886584,
     "wof:name":"Mateur",
     "wof:parent_id":85679113,
     "wof:placetype":"county",

--- a/data/110/875/729/7/1108757297.geojson
+++ b/data/110/875/729/7/1108757297.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012771,
-    "geom:area_square_m":125939251.594322,
+    "geom:area_square_m":125938942.228328,
     "geom:bbox":"9.773962,37.042047,9.938367,37.174777",
     "geom:latitude":37.108316,
     "geom:longitude":9.846601,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.BZ.MB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307135,
-    "wof:geomhash":"07e8963f37afd6628f84b9660cf6a911",
+    "wof:geomhash":"0e2f733ae7b4bfbf146f41ed9cc15ecb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757297,
-    "wof:lastmodified":1627522831,
+    "wof:lastmodified":1695886542,
     "wof:name":"Menzel Bourgiba",
     "wof:parent_id":85679113,
     "wof:placetype":"county",

--- a/data/110/875/729/9/1108757299.geojson
+++ b/data/110/875/729/9/1108757299.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009768,
-    "geom:area_square_m":96195009.474444,
+    "geom:area_square_m":96194993.677817,
     "geom:bbox":"9.822086,37.144436,10.031942,37.260841",
     "geom:latitude":37.212956,
     "geom:longitude":9.950102,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.BZ.MJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307137,
-    "wof:geomhash":"94168dcef3841ade0ff338f26fc19cda",
+    "wof:geomhash":"d40711c5028c1cbfe36d878b9da15019",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757299,
-    "wof:lastmodified":1627522832,
+    "wof:lastmodified":1695886544,
     "wof:name":"Menzel Jmil",
     "wof:parent_id":85679113,
     "wof:placetype":"county",

--- a/data/110/875/730/1/1108757301.geojson
+++ b/data/110/875/730/1/1108757301.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009271,
-    "geom:area_square_m":91288935.726964,
+    "geom:area_square_m":91288935.726961,
     "geom:bbox":"10.0097388153,37.1773112498,10.2140649105,37.271251678",
     "geom:latitude":37.218741,
     "geom:longitude":10.102747,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"TN.BZ.RJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307138,
-    "wof:geomhash":"574ac771ff05466190c8b2c7f7b265d1",
+    "wof:geomhash":"dfd1b71d33231f569d10f11657e29ec7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1108757301,
-    "wof:lastmodified":1566667239,
+    "wof:lastmodified":1695886578,
     "wof:name":"Ras Jebel",
     "wof:parent_id":85679113,
     "wof:placetype":"county",

--- a/data/110/875/730/3/1108757303.geojson
+++ b/data/110/875/730/3/1108757303.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.064856,
-    "geom:area_square_m":639302632.173659,
+    "geom:area_square_m":639302632.173666,
     "geom:bbox":"9.0800661498,37.0018500982,9.50549363065,37.272083282",
     "geom:latitude":37.137964,
     "geom:longitude":9.283169,
@@ -87,9 +87,10 @@
     "wof:concordances":{
         "hasc:id":"TN.BZ.SE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307139,
-    "wof:geomhash":"2a7e066ba23f695ddb87bcd96435e6fc",
+    "wof:geomhash":"2c9e4fc097d8c2a26473235fc9fe17f1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":1108757303,
-    "wof:lastmodified":1566667240,
+    "wof:lastmodified":1695886578,
     "wof:name":"Sejnane",
     "wof:parent_id":85679113,
     "wof:placetype":"county",

--- a/data/110/875/730/5/1108757305.geojson
+++ b/data/110/875/730/5/1108757305.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.039282,
-    "geom:area_square_m":387770327.433967,
+    "geom:area_square_m":387770502.240107,
     "geom:bbox":"9.822246,36.916412,10.226225,37.148724",
     "geom:latitude":37.029452,
     "geom:longitude":9.977847,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.BZ.UT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307140,
-    "wof:geomhash":"e4194f1cae257b627e11b6b447e29792",
+    "wof:geomhash":"1150a815563b61ee281a9cda9c05cdb8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757305,
-    "wof:lastmodified":1627522835,
+    "wof:lastmodified":1695886550,
     "wof:name":"Utique",
     "wof:parent_id":85679113,
     "wof:placetype":"county",

--- a/data/110/875/730/7/1108757307.geojson
+++ b/data/110/875/730/7/1108757307.geojson
@@ -96,9 +96,10 @@
     "wof:concordances":{
         "hasc:id":"TN.GB.HA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307142,
-    "wof:geomhash":"5e1f13bc619f8b2221abf31a861a1597",
+    "wof:geomhash":"fbf8d7fa807b9a4169ba7c10036f1336",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108757307,
-    "wof:lastmodified":1566667239,
+    "wof:lastmodified":1695886578,
     "wof:name":"El Hamma",
     "wof:parent_id":85679137,
     "wof:placetype":"county",

--- a/data/110/875/730/9/1108757309.geojson
+++ b/data/110/875/730/9/1108757309.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001952,
-    "geom:area_square_m":20033570.142625,
+    "geom:area_square_m":20033482.484666,
     "geom:bbox":"10.074458,33.864171,10.125274,33.935112",
     "geom:latitude":33.896312,
     "geom:longitude":10.094777,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.GB.GV"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307143,
-    "wof:geomhash":"512813ec74be0d27ea0de6715fdfc37f",
+    "wof:geomhash":"0a8dcb9020e4bec7dc3590dff22e765e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757309,
-    "wof:lastmodified":1627522827,
+    "wof:lastmodified":1695886534,
     "wof:name":"Gab\u00e9s Medina",
     "wof:parent_id":85679137,
     "wof:placetype":"county",

--- a/data/110/875/731/1/1108757311.geojson
+++ b/data/110/875/731/1/1108757311.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018841,
-    "geom:area_square_m":193485599.503223,
+    "geom:area_square_m":193485602.589329,
     "geom:bbox":"9.909394,33.730838,10.081552,33.935584",
     "geom:latitude":33.850664,
     "geom:longitude":9.987807,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.GB.GO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307144,
-    "wof:geomhash":"efe640c6d91eaaefcc180d6b047ca329",
+    "wof:geomhash":"4efeccbe31609731202c0bb1dabc0ef1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757311,
-    "wof:lastmodified":1627522827,
+    "wof:lastmodified":1695886534,
     "wof:name":"Gab\u00e9s Ouest",
     "wof:parent_id":85679137,
     "wof:placetype":"county",

--- a/data/110/875/731/5/1108757315.geojson
+++ b/data/110/875/731/5/1108757315.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.025479,
-    "geom:area_square_m":261860692.336447,
+    "geom:area_square_m":261860648.610598,
     "geom:bbox":"9.956752,33.689351,10.189534,33.887615",
     "geom:latitude":33.782105,
     "geom:longitude":10.081586,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.GB.GS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307145,
-    "wof:geomhash":"df616fe55e155a9f7545d93cc671866d",
+    "wof:geomhash":"6b744e23a5a64f77ffe02b86622d27ec",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757315,
-    "wof:lastmodified":1627522827,
+    "wof:lastmodified":1695886534,
     "wof:name":"Gab\u00e9s sud",
     "wof:parent_id":85679137,
     "wof:placetype":"county",

--- a/data/110/875/731/7/1108757317.geojson
+++ b/data/110/875/731/7/1108757317.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001699,
-    "geom:area_square_m":17425956.920727,
+    "geom:area_square_m":17426031.703063,
     "geom:bbox":"10.02731,33.915701,10.086983,33.96764",
     "geom:latitude":33.939219,
     "geom:longitude":10.058735,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.GB.GA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307146,
-    "wof:geomhash":"ad9a937fd19323f191405cd3fe22924b",
+    "wof:geomhash":"cb930bd2e9c14e0989928eeb1abdd145",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757317,
-    "wof:lastmodified":1627522828,
+    "wof:lastmodified":1695886536,
     "wof:name":"Gannouch",
     "wof:parent_id":85679137,
     "wof:placetype":"county",

--- a/data/110/875/731/9/1108757319.geojson
+++ b/data/110/875/731/9/1108757319.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.091928,
-    "geom:area_square_m":947133206.16788,
+    "geom:area_square_m":947133206.167883,
     "geom:bbox":"10.0024574189,33.2952473078,10.4744030687,33.8188904152",
     "geom:latitude":33.568482,
     "geom:longitude":10.226555,
@@ -78,9 +78,10 @@
     "wof:concordances":{
         "hasc:id":"TN.GB.MR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307147,
-    "wof:geomhash":"6f448266671969dac975817738d3c334",
+    "wof:geomhash":"c597fb031056045301572d7194cdc232",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1108757319,
-    "wof:lastmodified":1566667245,
+    "wof:lastmodified":1695886579,
     "wof:name":"Mareth",
     "wof:parent_id":85679137,
     "wof:placetype":"county",

--- a/data/110/875/732/1/1108757321.geojson
+++ b/data/110/875/732/1/1108757321.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.12372,
-    "geom:area_square_m":1276600151.16952,
+    "geom:area_square_m":1276600151.169529,
     "geom:bbox":"9.52672978462,33.265366835,10.0776039379,33.6443556068",
     "geom:latitude":33.438769,
     "geom:longitude":9.813184,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"TN.GB.MT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307148,
-    "wof:geomhash":"c06c2806d349a89cf356de1d395298d0",
+    "wof:geomhash":"24b95dfd1aa4ebc84d7c6a32aa0513b6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1108757321,
-    "wof:lastmodified":1566667260,
+    "wof:lastmodified":1695886581,
     "wof:name":"Matmata",
     "wof:parent_id":85679137,
     "wof:placetype":"county",

--- a/data/110/875/732/3/1108757323.geojson
+++ b/data/110/875/732/3/1108757323.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.070815,
-    "geom:area_square_m":729175341.828907,
+    "geom:area_square_m":729174739.625615,
     "geom:bbox":"9.614047,33.478765,10.166059,33.739531",
     "geom:latitude":33.618976,
     "geom:longitude":9.942768,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.GB.MN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307150,
-    "wof:geomhash":"10079a4bcd72b823b9e15141b37b8f0b",
+    "wof:geomhash":"4dbf544e1e0c20fb951d7f0d65bfbef5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757323,
-    "wof:lastmodified":1627522832,
+    "wof:lastmodified":1695886544,
     "wof:name":"Matmata Nouvelle",
     "wof:parent_id":85679137,
     "wof:placetype":"county",

--- a/data/110/875/732/5/1108757325.geojson
+++ b/data/110/875/732/5/1108757325.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.087828,
-    "geom:area_square_m":898677956.45619,
+    "geom:area_square_m":898677976.002848,
     "geom:bbox":"9.252409,34.030847,9.935054,34.271099",
     "geom:latitude":34.157174,
     "geom:longitude":9.627469,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.GB.MH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307151,
-    "wof:geomhash":"62ed58d6970a61522d8dd17b186be349",
+    "wof:geomhash":"e5cc4a0b2e25bb5ec739bfa9a1e31e92",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757325,
-    "wof:lastmodified":1627522831,
+    "wof:lastmodified":1695886542,
     "wof:name":"Menzel El Habib",
     "wof:parent_id":85679137,
     "wof:placetype":"county",

--- a/data/110/875/732/7/1108757327.geojson
+++ b/data/110/875/732/7/1108757327.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.042214,
-    "geom:area_square_m":432555279.103543,
+    "geom:area_square_m":432555438.578372,
     "geom:bbox":"9.822016,33.889443,10.067419,34.203702",
     "geom:latitude":34.036451,
     "geom:longitude":9.954672,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.GB.ME"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307152,
-    "wof:geomhash":"d3dc4e5c3211d16dbe3a683d230d3301",
+    "wof:geomhash":"16a047010a6e00a199629ab32097edcf",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757327,
-    "wof:lastmodified":1627522832,
+    "wof:lastmodified":1695886544,
     "wof:name":"Metouia",
     "wof:parent_id":85679137,
     "wof:placetype":"county",

--- a/data/110/875/732/9/1108757329.geojson
+++ b/data/110/875/732/9/1108757329.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.073236,
-    "geom:area_square_m":747859766.422044,
+    "geom:area_square_m":747859623.851792,
     "geom:bbox":"9.180878,34.177217,9.574618,34.480561",
     "geom:latitude":34.326519,
     "geom:longitude":9.386998,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.GF.BE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307153,
-    "wof:geomhash":"7553f451326dc6a25320cf0687c8614b",
+    "wof:geomhash":"46f834367e00be61f24c999466b6fc15",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757329,
-    "wof:lastmodified":1627522824,
+    "wof:lastmodified":1695886530,
     "wof:name":"Belkhir",
     "wof:parent_id":85679141,
     "wof:placetype":"county",

--- a/data/110/875/733/3/1108757333.geojson
+++ b/data/110/875/733/3/1108757333.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.054003,
-    "geom:area_square_m":549801375.887666,
+    "geom:area_square_m":549801291.682666,
     "geom:bbox":"8.703491,34.424621,9.155541,34.730393",
     "geom:latitude":34.577356,
     "geom:longitude":8.916497,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.GF.GN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307154,
-    "wof:geomhash":"60264916401d8d5aaa49cc18c2d9ac6d",
+    "wof:geomhash":"18a7b9068e9da176e1f8ea9cd17372e0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757333,
-    "wof:lastmodified":1627522828,
+    "wof:lastmodified":1695886536,
     "wof:name":"Gafsa nord",
     "wof:parent_id":85679141,
     "wof:placetype":"county",

--- a/data/110/875/733/5/1108757335.geojson
+++ b/data/110/875/733/5/1108757335.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.076251,
-    "geom:area_square_m":777447897.977749,
+    "geom:area_square_m":777447852.117108,
     "geom:bbox":"8.460539,34.233789,8.81525,34.671907",
     "geom:latitude":34.455906,
     "geom:longitude":8.629976,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.GF.GS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307155,
-    "wof:geomhash":"546e84311c45fc7146af83a087b60e2c",
+    "wof:geomhash":"eefa92edc45b7f07bd4a2c62a07f4efd",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757335,
-    "wof:lastmodified":1627522828,
+    "wof:lastmodified":1695886536,
     "wof:name":"Gafsa Sud",
     "wof:parent_id":85679141,
     "wof:placetype":"county",

--- a/data/110/875/733/7/1108757337.geojson
+++ b/data/110/875/733/7/1108757337.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.097871,
-    "geom:area_square_m":1000086949.95391,
+    "geom:area_square_m":1000086533.130108,
     "geom:bbox":"8.780444,34.08984,9.306484,34.430001",
     "geom:latitude":34.271082,
     "geom:longitude":9.031162,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.GF.GU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307156,
-    "wof:geomhash":"5eb0d21e7a64ade74b6e002559b10894",
+    "wof:geomhash":"0b1c5abde225266d22ac42f1bad383eb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757337,
-    "wof:lastmodified":1627522828,
+    "wof:lastmodified":1695886536,
     "wof:name":"Guetar",
     "wof:parent_id":85679141,
     "wof:placetype":"county",

--- a/data/110/875/733/9/1108757339.geojson
+++ b/data/110/875/733/9/1108757339.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.028448,
-    "geom:area_square_m":290234266.149559,
+    "geom:area_square_m":290234266.14955,
     "geom:bbox":"8.71320457484,34.3181416273,9.04945157238,34.4956843378",
     "geom:latitude":34.404668,
     "geom:longitude":8.892327,
@@ -126,9 +126,10 @@
     "wof:concordances":{
         "hasc:id":"TN.GF.KS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307157,
-    "wof:geomhash":"9becab5393e27f12e67e5dfed8f43520",
+    "wof:geomhash":"7c3472ce7d48996e4fef56253771c5c2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":1108757339,
-    "wof:lastmodified":1566667255,
+    "wof:lastmodified":1695886581,
     "wof:name":"Ksar",
     "wof:parent_id":85679141,
     "wof:placetype":"county",

--- a/data/110/875/734/1/1108757341.geojson
+++ b/data/110/875/734/1/1108757341.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.062015,
-    "geom:area_square_m":634251356.82072,
+    "geom:area_square_m":634251356.820669,
     "geom:bbox":"8.51144313063,34.0765819094,8.92447958822,34.3289205522",
     "geom:latitude":34.197353,
     "geom:longitude":8.704723,
@@ -78,9 +78,10 @@
     "wof:concordances":{
         "hasc:id":"TN.GF.MD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307158,
-    "wof:geomhash":"24bf592b13aa80ee71b50683851ba45a",
+    "wof:geomhash":"86d6d871684121742c58f515fe735e8d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1108757341,
-    "wof:lastmodified":1566667254,
+    "wof:lastmodified":1695886581,
     "wof:name":"Mdhila",
     "wof:parent_id":85679141,
     "wof:placetype":"county",

--- a/data/110/875/734/3/1108757343.geojson
+++ b/data/110/875/734/3/1108757343.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.093798,
-    "geom:area_square_m":958937340.06599,
+    "geom:area_square_m":958937000.226405,
     "geom:bbox":"8.142666,34.070451,8.586146,34.415941",
     "geom:latitude":34.229344,
     "geom:longitude":8.382339,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.GF.ME"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307160,
-    "wof:geomhash":"ff6f9fd820231662da8cef02285723ab",
+    "wof:geomhash":"c25c5b101e3bc3e08e81a74fc16d3f62",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757343,
-    "wof:lastmodified":1627522832,
+    "wof:lastmodified":1695886544,
     "wof:name":"Metlaoui",
     "wof:parent_id":85679141,
     "wof:placetype":"county",

--- a/data/110/875/734/5/1108757345.geojson
+++ b/data/110/875/734/5/1108757345.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.099091,
-    "geom:area_square_m":1009269996.338822,
+    "geom:area_square_m":1009270205.145172,
     "geom:bbox":"8.101119,34.393577,8.630862,34.731957",
     "geom:latitude":34.542397,
     "geom:longitude":8.362473,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.GF.OL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307161,
-    "wof:geomhash":"4794798e3effc7d375424bb7708a9fc6",
+    "wof:geomhash":"3f5d5162ae340234db6d167de504e742",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757345,
-    "wof:lastmodified":1627522832,
+    "wof:lastmodified":1695886544,
     "wof:name":"Oum Lara\u00ed",
     "wof:parent_id":85679141,
     "wof:placetype":"county",

--- a/data/110/875/734/7/1108757347.geojson
+++ b/data/110/875/734/7/1108757347.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.044481,
-    "geom:area_square_m":454138171.262005,
+    "geom:area_square_m":454138171.261992,
     "geom:bbox":"8.03633663671,34.1884231781,8.34301679636,34.4641876043",
     "geom:latitude":34.341411,
     "geom:longitude":8.167057,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"TN.GF.RE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307162,
-    "wof:geomhash":"6bcfb396b20beae4a1eab71dd63f3052",
+    "wof:geomhash":"e0afbd8f1381b58439cec117459a0482",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1108757347,
-    "wof:lastmodified":1566667254,
+    "wof:lastmodified":1695886581,
     "wof:name":"Redeyef",
     "wof:parent_id":85679141,
     "wof:placetype":"county",

--- a/data/110/875/735/1/1108757351.geojson
+++ b/data/110/875/735/1/1108757351.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.071521,
-    "geom:area_square_m":728568993.54518,
+    "geom:area_square_m":728568869.981545,
     "geom:bbox":"8.9747,34.374685,9.326312,34.703985",
     "geom:latitude":34.530244,
     "geom:longitude":9.156709,
@@ -75,9 +75,10 @@
     "wof:concordances":{
         "hasc:id":"TN.GF.SE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307163,
-    "wof:geomhash":"f907b246baa2442f7dd0ce1a8892676b",
+    "wof:geomhash":"1d9c8684c6b656b139659009cb71b996",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -87,7 +88,7 @@
         }
     ],
     "wof:id":1108757351,
-    "wof:lastmodified":1627522833,
+    "wof:lastmodified":1695886546,
     "wof:name":"Sened",
     "wof:parent_id":85679141,
     "wof:placetype":"county",

--- a/data/110/875/735/3/1108757353.geojson
+++ b/data/110/875/735/3/1108757353.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.042279,
-    "geom:area_square_m":429887702.659576,
+    "geom:area_square_m":429887784.254652,
     "geom:bbox":"8.630271,34.580871,8.962529,34.805777",
     "geom:latitude":34.684588,
     "geom:longitude":8.819653,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.GF.SA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307164,
-    "wof:geomhash":"6940d700238e732e5f5d345d69d848eb",
+    "wof:geomhash":"6c0a24043162e36ede43a641e7351967",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757353,
-    "wof:lastmodified":1627522834,
+    "wof:lastmodified":1695886548,
     "wof:name":"Sidi A\u00ed\u0107h",
     "wof:parent_id":85679141,
     "wof:placetype":"county",

--- a/data/110/875/735/5/1108757355.geojson
+++ b/data/110/875/735/5/1108757355.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.050855,
-    "geom:area_square_m":503683766.489355,
+    "geom:area_square_m":503683706.868736,
     "geom:bbox":"8.42946,36.67596,8.924421,36.913623",
     "geom:latitude":36.775542,
     "geom:longitude":8.697438,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.JE.AD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307166,
-    "wof:geomhash":"111fb6a03439a2a377aa2d93bfdd466c",
+    "wof:geomhash":"57b5ffa4faac141037a760a7367f8d4a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757355,
-    "wof:lastmodified":1627522823,
+    "wof:lastmodified":1695886529,
     "wof:name":"Ain Drahem",
     "wof:parent_id":85679115,
     "wof:placetype":"county",

--- a/data/110/875/735/7/1108757357.geojson
+++ b/data/110/875/735/7/1108757357.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.028882,
-    "geom:area_square_m":286399236.375151,
+    "geom:area_square_m":286399272.86931,
     "geom:bbox":"8.78225,36.601233,9.031771,36.771615",
     "geom:latitude":36.685064,
     "geom:longitude":8.917269,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.JE.BB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307167,
-    "wof:geomhash":"b04e282baead7278144bd5ad2ff83d82",
+    "wof:geomhash":"cdb0bd5e240f4a78198d28a070f3beaf",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757357,
-    "wof:lastmodified":1627522824,
+    "wof:lastmodified":1695886530,
     "wof:name":"Balta Bouaouan",
     "wof:parent_id":85679115,
     "wof:placetype":"county",

--- a/data/110/875/735/9/1108757359.geojson
+++ b/data/110/875/735/9/1108757359.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.029953,
-    "geom:area_square_m":297535948.663393,
+    "geom:area_square_m":297535959.911174,
     "geom:bbox":"8.837012,36.447799,9.074043,36.654096",
     "geom:latitude":36.550394,
     "geom:longitude":8.971669,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.JE.BS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307169,
-    "wof:geomhash":"bb0380a2e26ba7bb176b49ce44dfa3ab",
+    "wof:geomhash":"029a4864f0af3a7977d8ea39ff2a0150",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757359,
-    "wof:lastmodified":1627522825,
+    "wof:lastmodified":1695886531,
     "wof:name":"Bousalem",
     "wof:parent_id":85679115,
     "wof:placetype":"county",

--- a/data/110/875/736/1/1108757361.geojson
+++ b/data/110/875/736/1/1108757361.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.039601,
-    "geom:area_square_m":392877347.472856,
+    "geom:area_square_m":392877347.472858,
     "geom:bbox":"8.44825455389,36.5687256855,8.81753102596,36.7408473276",
     "geom:latitude":36.647125,
     "geom:longitude":8.641522,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"TN.JE.FE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307170,
-    "wof:geomhash":"eaf2d5bc1ec58bcd62b95d5774a0bb1f",
+    "wof:geomhash":"47b3d944f715f7e815c5b41cfa18a881",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1108757361,
-    "wof:lastmodified":1566667244,
+    "wof:lastmodified":1695886579,
     "wof:name":"Fernana",
     "wof:parent_id":85679115,
     "wof:placetype":"county",

--- a/data/110/875/736/3/1108757363.geojson
+++ b/data/110/875/736/3/1108757363.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.051726,
-    "geom:area_square_m":514215170.723514,
+    "geom:area_square_m":514215352.959745,
     "geom:bbox":"8.153737,36.342899,8.531251,36.62541",
     "geom:latitude":36.490373,
     "geom:longitude":8.381644,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.JE.GH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307171,
-    "wof:geomhash":"b12a0afc3d75985383491804c5391e63",
+    "wof:geomhash":"dceba99b02eccd95f1959f2cf7f1fcd6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757363,
-    "wof:lastmodified":1627522828,
+    "wof:lastmodified":1695886536,
     "wof:name":"Ghar Dimaou",
     "wof:parent_id":85679115,
     "wof:placetype":"county",

--- a/data/110/875/736/5/1108757365.geojson
+++ b/data/110/875/736/5/1108757365.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.025058,
-    "geom:area_square_m":249191816.531085,
+    "geom:area_square_m":249191874.271675,
     "geom:bbox":"8.662752,36.39442,8.932489,36.569165",
     "geom:latitude":36.462925,
     "geom:longitude":8.810333,
@@ -150,9 +150,10 @@
     "wof:concordances":{
         "hasc:id":"TN.JE.JE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307172,
-    "wof:geomhash":"5869667a155ad3c623c7a33aeca96b79",
+    "wof:geomhash":"85ab0bdce8f2585e733775d8f080ef55",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -162,7 +163,7 @@
         }
     ],
     "wof:id":1108757365,
-    "wof:lastmodified":1636495671,
+    "wof:lastmodified":1695886660,
     "wof:name":"Jendouba",
     "wof:parent_id":85679115,
     "wof:placetype":"county",

--- a/data/110/875/736/9/1108757369.geojson
+++ b/data/110/875/736/9/1108757369.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.029466,
-    "geom:area_square_m":292732110.616652,
+    "geom:area_square_m":292732198.637158,
     "geom:bbox":"8.520668,36.450518,8.870461,36.60926",
     "geom:latitude":36.540371,
     "geom:longitude":8.687255,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.JE.JN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307173,
-    "wof:geomhash":"43c948bf78aab40715c4b519f9dbb716",
+    "wof:geomhash":"c756ff1c0db5e34a0ea5b2d4bbe694fe",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757369,
-    "wof:lastmodified":1627522829,
+    "wof:lastmodified":1695886538,
     "wof:name":"Jendouba Nord",
     "wof:parent_id":85679115,
     "wof:placetype":"county",

--- a/data/110/875/737/1/1108757371.geojson
+++ b/data/110/875/737/1/1108757371.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019358,
-    "geom:area_square_m":192514153.789092,
+    "geom:area_square_m":192514047.62925,
     "geom:bbox":"8.489496,36.391518,8.672922,36.574485",
     "geom:latitude":36.460441,
     "geom:longitude":8.571196,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.JE.OM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307174,
-    "wof:geomhash":"59182a65e30c1f3dff5bd1e0831a5278",
+    "wof:geomhash":"a1a7d3690d07d9efe19193623a6c2866",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757371,
-    "wof:lastmodified":1627522832,
+    "wof:lastmodified":1695886545,
     "wof:name":"Oued Mliz",
     "wof:parent_id":85679115,
     "wof:placetype":"county",

--- a/data/110/875/737/3/1108757373.geojson
+++ b/data/110/875/737/3/1108757373.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.038991,
-    "geom:area_square_m":385533070.365539,
+    "geom:area_square_m":385533070.365533,
     "geom:bbox":"8.641884,36.8022473926,9.00189315253,37.012380522",
     "geom:latitude":36.90441,
     "geom:longitude":8.831742,
@@ -135,9 +135,10 @@
     "wof:concordances":{
         "hasc:id":"TN.JE.TA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307175,
-    "wof:geomhash":"3b9a8708f6ffb87555d421b6dd80fddc",
+    "wof:geomhash":"ed6858f1a31074519b7ccf6e43c27a07",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -147,7 +148,7 @@
         }
     ],
     "wof:id":1108757373,
-    "wof:lastmodified":1566667240,
+    "wof:lastmodified":1695886578,
     "wof:name":"Tabarka",
     "wof:parent_id":85679115,
     "wof:placetype":"county",

--- a/data/110/875/737/5/1108757375.geojson
+++ b/data/110/875/737/5/1108757375.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.038269,
-    "geom:area_square_m":384562795.095321,
+    "geom:area_square_m":384563250.648916,
     "geom:bbox":"9.267726,35.533509,9.692318,35.740978",
     "geom:latitude":35.641937,
     "geom:longitude":9.470144,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.KR.AL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307176,
-    "wof:geomhash":"1f5e9ef8781ce660e35732df1878aa7c",
+    "wof:geomhash":"fc251e08f1cff829d379ce61228898f7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757375,
-    "wof:lastmodified":1627522826,
+    "wof:lastmodified":1695886532,
     "wof:name":"Alaa",
     "wof:parent_id":85679171,
     "wof:placetype":"county",

--- a/data/110/875/737/7/1108757377.geojson
+++ b/data/110/875/737/7/1108757377.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.064095,
-    "geom:area_square_m":646333001.550042,
+    "geom:area_square_m":646333127.126328,
     "geom:bbox":"9.89369,35.203556,10.220073,35.500262",
     "geom:latitude":35.361587,
     "geom:longitude":10.064589,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.KR.SA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307177,
-    "wof:geomhash":"7a6662bb1e3eaa7d9cf60a6f4770a08f",
+    "wof:geomhash":"fae2d38c7fdead5c4fff654d5445da11",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757377,
-    "wof:lastmodified":1627522825,
+    "wof:lastmodified":1695886531,
     "wof:name":"Bouhajla",
     "wof:parent_id":85679171,
     "wof:placetype":"county",

--- a/data/110/875/737/9/1108757379.geojson
+++ b/data/110/875/737/9/1108757379.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.04959,
-    "geom:area_square_m":498317088.679031,
+    "geom:area_square_m":498317301.836241,
     "geom:bbox":"9.782532,35.490081,10.042083,35.820968",
     "geom:latitude":35.642646,
     "geom:longitude":9.913182,
@@ -78,9 +78,10 @@
     "wof:concordances":{
         "hasc:id":"TN.KR.CB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307179,
-    "wof:geomhash":"7e4301c4f1c446fc044b627148b9a808",
+    "wof:geomhash":"1bd053770f455129d7b822398018160f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1108757379,
-    "wof:lastmodified":1627522825,
+    "wof:lastmodified":1695886531,
     "wof:name":"Chbika",
     "wof:parent_id":85679171,
     "wof:placetype":"county",

--- a/data/110/875/738/1/1108757381.geojson
+++ b/data/110/875/738/1/1108757381.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.034764,
-    "geom:area_square_m":351436052.261783,
+    "geom:area_square_m":351436220.758207,
     "geom:bbox":"9.949292,35.00682,10.221752,35.276852",
     "geom:latitude":35.158771,
     "geom:longitude":10.067481,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.KR.CR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307180,
-    "wof:geomhash":"bad08226e01cc8e23563410e385c8688",
+    "wof:geomhash":"47d7cc5563dae26d0ed5665c97e629c3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757381,
-    "wof:lastmodified":1627522825,
+    "wof:lastmodified":1695886531,
     "wof:name":"Chrarda",
     "wof:parent_id":85679171,
     "wof:placetype":"county",

--- a/data/110/875/738/3/1108757383.geojson
+++ b/data/110/875/738/3/1108757383.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.060694,
-    "geom:area_square_m":610092332.780792,
+    "geom:area_square_m":610092332.78079,
     "geom:bbox":"9.54022515579,35.455284482,9.85742499005,35.7867587591",
     "geom:latitude":35.616933,
     "geom:longitude":9.709753,
@@ -84,9 +84,10 @@
     "wof:concordances":{
         "hasc:id":"TN.KR.HF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307181,
-    "wof:geomhash":"483c93503e7806ce0afe89cb784f4ec8",
+    "wof:geomhash":"f545f8ed6206f647ed9c5b151fd1dd27",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":1108757383,
-    "wof:lastmodified":1566667246,
+    "wof:lastmodified":1695886579,
     "wof:name":"Haffouz",
     "wof:parent_id":85679171,
     "wof:placetype":"county",

--- a/data/110/875/738/7/1108757387.geojson
+++ b/data/110/875/738/7/1108757387.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.059736,
-    "geom:area_square_m":601949420.212459,
+    "geom:area_square_m":601949420.212443,
     "geom:bbox":"9.40445179528,35.2344341806,9.727319697,35.5949884068",
     "geom:latitude":35.419666,
     "geom:longitude":9.575893,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"TN.KR.HA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307182,
-    "wof:geomhash":"9abda1b52a538f788b1890945aaec793",
+    "wof:geomhash":"1e72f3c7060da791310781bd8c18ce85",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1108757387,
-    "wof:lastmodified":1566667246,
+    "wof:lastmodified":1695886579,
     "wof:name":"Hajeb El Ayoun",
     "wof:parent_id":85679171,
     "wof:placetype":"county",

--- a/data/110/875/738/9/1108757389.geojson
+++ b/data/110/875/738/9/1108757389.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.026143,
-    "geom:area_square_m":262402062.269852,
+    "geom:area_square_m":262402083.829904,
     "geom:bbox":"9.972698,35.667155,10.251782,35.810901",
     "geom:latitude":35.734784,
     "geom:longitude":10.100062,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.KR.KN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307183,
-    "wof:geomhash":"c04ce39699f1407ae33551205b9d56d0",
+    "wof:geomhash":"b4b5e56059fe38741f16b6491b12a3d9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757389,
-    "wof:lastmodified":1627522829,
+    "wof:lastmodified":1695886538,
     "wof:name":"Kairouan Nord",
     "wof:parent_id":85679171,
     "wof:placetype":"county",

--- a/data/110/875/739/1/1108757391.geojson
+++ b/data/110/875/739/1/1108757391.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.056023,
-    "geom:area_square_m":563443910.503671,
+    "geom:area_square_m":563444009.383673,
     "geom:bbox":"9.88806,35.442161,10.304758,35.701875",
     "geom:latitude":35.574781,
     "geom:longitude":10.115844,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.KR.KS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307184,
-    "wof:geomhash":"d4ac86c3f1e2a250e3cfd0808a2daf1f",
+    "wof:geomhash":"c325c72ad343ef515c4e45d38270dbe0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757391,
-    "wof:lastmodified":1627522829,
+    "wof:lastmodified":1695886538,
     "wof:name":"Kairouan Sud",
     "wof:parent_id":85679171,
     "wof:placetype":"county",

--- a/data/110/875/739/3/1108757393.geojson
+++ b/data/110/875/739/3/1108757393.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.069584,
-    "geom:area_square_m":702070091.749691,
+    "geom:area_square_m":702069853.268505,
     "geom:bbox":"9.685398,35.164502,9.965802,35.49929",
     "geom:latitude":35.317656,
     "geom:longitude":9.817811,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.KR.NA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307185,
-    "wof:geomhash":"9f307903c042aad4ea40099ac10d99f6",
+    "wof:geomhash":"a8750b4ff13fdb6242aed83a3146d376",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757393,
-    "wof:lastmodified":1627522832,
+    "wof:lastmodified":1695886545,
     "wof:name":"Nasrallah",
     "wof:parent_id":85679171,
     "wof:placetype":"county",

--- a/data/110/875/739/5/1108757395.geojson
+++ b/data/110/875/739/5/1108757395.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.089933,
-    "geom:area_square_m":901037494.159492,
+    "geom:area_square_m":901037494.159514,
     "geom:bbox":"9.48964271847,35.674568753,9.86353656296,36.1058966041",
     "geom:latitude":35.879041,
     "geom:longitude":9.684741,
@@ -75,9 +75,10 @@
     "wof:concordances":{
         "hasc:id":"TN.KR.OU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307186,
-    "wof:geomhash":"f799cfb56d4f7afce1ef683079dc99bd",
+    "wof:geomhash":"d32e8c79fb11a4781cb6e699ae33a9b3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -87,7 +88,7 @@
         }
     ],
     "wof:id":1108757395,
-    "wof:lastmodified":1566667239,
+    "wof:lastmodified":1695886578,
     "wof:name":"Oueslatia",
     "wof:parent_id":85679171,
     "wof:placetype":"county",

--- a/data/110/875/739/7/1108757397.geojson
+++ b/data/110/875/739/7/1108757397.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.102864,
-    "geom:area_square_m":1029836991.796945,
+    "geom:area_square_m":1029836991.79699,
     "geom:bbox":"9.77347261354,35.7620114783,10.2556458695,36.1367954848",
     "geom:latitude":35.936627,
     "geom:longitude":10.02506,
@@ -78,9 +78,10 @@
     "wof:concordances":{
         "hasc:id":"TN.KR.SB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307187,
-    "wof:geomhash":"1a77be4dee699ac0e8ac4d3f8487de05",
+    "wof:geomhash":"027f5cc1518eb52236685e94d583d3f6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1108757397,
-    "wof:lastmodified":1566667238,
+    "wof:lastmodified":1695886577,
     "wof:name":"Sbikha",
     "wof:parent_id":85679171,
     "wof:placetype":"county",

--- a/data/110/875/739/9/1108757399.geojson
+++ b/data/110/875/739/9/1108757399.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.039982,
-    "geom:area_square_m":402458975.882588,
+    "geom:area_square_m":402459122.637182,
     "geom:bbox":"8.761861,35.35867,9.012595,35.610029",
     "geom:latitude":35.504873,
     "geom:longitude":8.888452,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.KS.AY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307189,
-    "wof:geomhash":"213471763c399e24a2195546facfb574",
+    "wof:geomhash":"40dcc796a5f13337ca8013660c3ace00",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757399,
-    "wof:lastmodified":1627522824,
+    "wof:lastmodified":1695886530,
     "wof:name":"Ayoun",
     "wof:parent_id":85679133,
     "wof:placetype":"county",

--- a/data/110/875/740/1/1108757401.geojson
+++ b/data/110/875/740/1/1108757401.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.028661,
-    "geom:area_square_m":288002368.362354,
+    "geom:area_square_m":288002322.416647,
     "geom:bbox":"8.766966,35.558808,9.086512,35.737318",
     "geom:latitude":35.642933,
     "geom:longitude":8.91738,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.KS.DJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307190,
-    "wof:geomhash":"d77bee3e6b948db9efa1d049e487b332",
+    "wof:geomhash":"ace3a83eb5537c57647c9706002e37e3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757401,
-    "wof:lastmodified":1627522829,
+    "wof:lastmodified":1695886538,
     "wof:name":"Djedliane",
     "wof:parent_id":85679133,
     "wof:placetype":"county",

--- a/data/110/875/740/5/1108757405.geojson
+++ b/data/110/875/740/5/1108757405.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000187,
-    "geom:area_square_m":1890450.844855,
+    "geom:area_square_m":1890464.961087,
     "geom:bbox":"8.819342,35.148641,8.839328,35.160709",
     "geom:latitude":35.154764,
     "geom:longitude":8.829366,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.KS.EZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307191,
-    "wof:geomhash":"221f10a61f2d26bfb42071a25ad1d9e3",
+    "wof:geomhash":"78c84ab236b24fd89cf9c237437bc6c8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757405,
-    "wof:lastmodified":1627522827,
+    "wof:lastmodified":1695886534,
     "wof:name":"Ez_zouhour",
     "wof:parent_id":85679133,
     "wof:placetype":"county",

--- a/data/110/875/740/7/1108757407.geojson
+++ b/data/110/875/740/7/1108757407.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.094016,
-    "geom:area_square_m":952056461.352069,
+    "geom:area_square_m":952056367.760659,
     "geom:bbox":"8.245813,34.85094,8.667248,35.23483",
     "geom:latitude":35.019486,
     "geom:longitude":8.471091,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.KS.FE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307197,
-    "wof:geomhash":"cabf3e0d860da2f6b4743787076a42e8",
+    "wof:geomhash":"cd768996be7a13c679841c1d684f55ac",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757407,
-    "wof:lastmodified":1627522827,
+    "wof:lastmodified":1695886535,
     "wof:name":"Feriana",
     "wof:parent_id":85679133,
     "wof:placetype":"county",

--- a/data/110/875/740/9/1108757409.geojson
+++ b/data/110/875/740/9/1108757409.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.093854,
-    "geom:area_square_m":946748035.468368,
+    "geom:area_square_m":946747920.994541,
     "geom:bbox":"8.310883,35.186985,8.828551,35.47435",
     "geom:latitude":35.333605,
     "geom:longitude":8.546882,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.KS.FO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307198,
-    "wof:geomhash":"6f0caa071c2b100c43279297f570c905",
+    "wof:geomhash":"d01eeec1a54931c146fe60c3f8da8fcb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757409,
-    "wof:lastmodified":1627522827,
+    "wof:lastmodified":1695886535,
     "wof:name":"Fousana",
     "wof:parent_id":85679133,
     "wof:placetype":"county",

--- a/data/110/875/741/1/1108757411.geojson
+++ b/data/110/875/741/1/1108757411.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.045862,
-    "geom:area_square_m":461406459.083495,
+    "geom:area_square_m":461406316.70249,
     "geom:bbox":"8.350494,35.408296,8.631153,35.670117",
     "geom:latitude":35.547927,
     "geom:longitude":8.481535,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.KS.HI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307199,
-    "wof:geomhash":"9065448dad34c1f9ee64749b31ce10d4",
+    "wof:geomhash":"4d3a20139b927fd5f622e96d11524cb0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757411,
-    "wof:lastmodified":1627522828,
+    "wof:lastmodified":1695886537,
     "wof:name":"Haidara",
     "wof:parent_id":85679133,
     "wof:placetype":"county",

--- a/data/110/875/741/3/1108757413.geojson
+++ b/data/110/875/741/3/1108757413.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.09679,
-    "geom:area_square_m":980878197.428552,
+    "geom:area_square_m":980878126.77703,
     "geom:bbox":"8.695777,34.762815,9.167629,35.148131",
     "geom:latitude":34.958354,
     "geom:longitude":8.932109,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.KS.HF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307200,
-    "wof:geomhash":"1f1e424972d114b8d57b38ee355fe012",
+    "wof:geomhash":"21de9375d6171aba1515a37907be9f74",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757413,
-    "wof:lastmodified":1627522828,
+    "wof:lastmodified":1695886537,
     "wof:name":"Hassi El Frid",
     "wof:parent_id":85679133,
     "wof:placetype":"county",

--- a/data/110/875/741/5/1108757415.geojson
+++ b/data/110/875/741/5/1108757415.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00923,
-    "geom:area_square_m":93263004.445224,
+    "geom:area_square_m":93262849.5066,
     "geom:bbox":"8.696228,35.150765,8.876333,35.245118",
     "geom:latitude":35.199525,
     "geom:longitude":8.790035,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.KS.KN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307201,
-    "wof:geomhash":"8f486f44a0458a6b203e5cdedb96056a",
+    "wof:geomhash":"fb0259e6e7c3fa84f64d5dac17842733",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757415,
-    "wof:lastmodified":1627522830,
+    "wof:lastmodified":1695886539,
     "wof:name":"Kasserine Nord",
     "wof:parent_id":85679133,
     "wof:placetype":"county",

--- a/data/110/875/741/7/1108757417.geojson
+++ b/data/110/875/741/7/1108757417.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.085673,
-    "geom:area_square_m":866673329.060394,
+    "geom:area_square_m":866673760.85615,
     "geom:bbox":"8.568317,34.881669,9.023573,35.307402",
     "geom:latitude":35.103946,
     "geom:longitude":8.767142,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.KS.KS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307202,
-    "wof:geomhash":"5d80ed5c3acd20d71d22d77f9d141109",
+    "wof:geomhash":"4b635e430faf548e5172036ff1ce3766",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757417,
-    "wof:lastmodified":1627522830,
+    "wof:lastmodified":1695886540,
     "wof:name":"kasserine sud",
     "wof:parent_id":85679133,
     "wof:placetype":"county",

--- a/data/110/875/741/9/1108757419.geojson
+++ b/data/110/875/741/9/1108757419.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.089707,
-    "geom:area_square_m":911104795.719223,
+    "geom:area_square_m":911104479.061348,
     "geom:bbox":"8.270369,34.631195,8.828503,34.897459",
     "geom:latitude":34.777117,
     "geom:longitude":8.53603,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.KS.MB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307204,
-    "wof:geomhash":"db5b27ca56b701c93db7b353bf1e5150",
+    "wof:geomhash":"937aea71885b1f916d6a59b95761e2b0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757419,
-    "wof:lastmodified":1627522831,
+    "wof:lastmodified":1695886542,
     "wof:name":"Majel Belabbes",
     "wof:parent_id":85679133,
     "wof:placetype":"county",

--- a/data/110/875/742/3/1108757423.geojson
+++ b/data/110/875/742/3/1108757423.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.045815,
-    "geom:area_square_m":461203450.088975,
+    "geom:area_square_m":461203450.088959,
     "geom:bbox":"8.98996511352,35.3644408497,9.33050589744,35.6165997063",
     "geom:latitude":35.499798,
     "geom:longitude":9.160354,
@@ -84,9 +84,10 @@
     "wof:concordances":{
         "hasc:id":"TN.KS.SB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307205,
-    "wof:geomhash":"d4a04082ba9f8b574ea8502fd154adaa",
+    "wof:geomhash":"f71da9036f1a82613344a03aa7b379b9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":1108757423,
-    "wof:lastmodified":1566667273,
+    "wof:lastmodified":1695886584,
     "wof:name":"Sbiba",
     "wof:parent_id":85679133,
     "wof:placetype":"county",

--- a/data/110/875/742/5/1108757425.geojson
+++ b/data/110/875/742/5/1108757425.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.109313,
-    "geom:area_square_m":1103793104.174546,
+    "geom:area_square_m":1103793184.45435,
     "geom:bbox":"8.801552,35.005974,9.32412,35.467665",
     "geom:latitude":35.25312,
     "geom:longitude":9.076984,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.KS.ST"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307206,
-    "wof:geomhash":"0012f036cdd83e399e639826ecb1646a",
+    "wof:geomhash":"75d15ce8710b02994092518df04dac5b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757425,
-    "wof:lastmodified":1627522833,
+    "wof:lastmodified":1695886546,
     "wof:name":"Sbitla",
     "wof:parent_id":85679133,
     "wof:placetype":"county",

--- a/data/110/875/742/7/1108757427.geojson
+++ b/data/110/875/742/7/1108757427.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.073135,
-    "geom:area_square_m":735455630.178435,
+    "geom:area_square_m":735455630.178462,
     "geom:bbox":"8.55827411173,35.3647653857,8.84412171598,35.7820065167",
     "geom:latitude":35.584176,
     "geom:longitude":8.70598,
@@ -117,9 +117,10 @@
     "wof:concordances":{
         "hasc:id":"TN.KS.TH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307207,
-    "wof:geomhash":"526bfd873785479449af900cd209f8c1",
+    "wof:geomhash":"da6e7bc0ae71a7273832db60818d880e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":1108757427,
-    "wof:lastmodified":1566667272,
+    "wof:lastmodified":1695886584,
     "wof:name":"Tala",
     "wof:parent_id":85679133,
     "wof:placetype":"county",

--- a/data/110/875/742/9/1108757429.geojson
+++ b/data/110/875/742/9/1108757429.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.342257,
-    "geom:area_square_m":3539385851.645385,
+    "geom:area_square_m":3539385473.901466,
     "geom:bbox":"8.911811,32.806776,9.97294,33.614259",
     "geom:latitude":33.24561,
     "geom:longitude":9.513818,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.KB.DN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307208,
-    "wof:geomhash":"32cfe93181a2568d4047eee00216beb1",
+    "wof:geomhash":"74ca6115d933ac29450ea7de45e2f0dc",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757429,
-    "wof:lastmodified":1627522826,
+    "wof:lastmodified":1695886533,
     "wof:name":"Douz Nord",
     "wof:parent_id":85679187,
     "wof:placetype":"county",

--- a/data/110/875/743/1/1108757431.geojson
+++ b/data/110/875/743/1/1108757431.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.473634,
-    "geom:area_square_m":4911659553.980222,
+    "geom:area_square_m":4911659222.061671,
     "geom:bbox":"8.80475,32.609573,9.969118,33.557405",
     "geom:latitude":33.000805,
     "geom:longitude":9.208671,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.KB.DS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307209,
-    "wof:geomhash":"97d63516368a4592cd7839e21ad0c7cd",
+    "wof:geomhash":"f0258f274de8f2029f53c5d4f15a7b63",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757431,
-    "wof:lastmodified":1627522826,
+    "wof:lastmodified":1695886533,
     "wof:name":"Douz Sud",
     "wof:parent_id":85679187,
     "wof:placetype":"county",

--- a/data/110/875/743/3/1108757433.geojson
+++ b/data/110/875/743/3/1108757433.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.916562,
-    "geom:area_square_m":9486865279.701618,
+    "geom:area_square_m":9486865515.680304,
     "geom:bbox":"7.744395,32.462897,9.010877,33.820201",
     "geom:latitude":33.168354,
     "geom:longitude":8.438871,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.KB.FA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307210,
-    "wof:geomhash":"ff07f5b2812bc814c3c4f4ceaa3d8fdf",
+    "wof:geomhash":"f8335ca7f118a7f9d0d9db5baa8687df",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757433,
-    "wof:lastmodified":1627522826,
+    "wof:lastmodified":1695886533,
     "wof:name":"El Faouar",
     "wof:parent_id":85679187,
     "wof:placetype":"county",

--- a/data/110/875/743/5/1108757435.geojson
+++ b/data/110/875/743/5/1108757435.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.070239,
-    "geom:area_square_m":721988494.972366,
+    "geom:area_square_m":721988585.929003,
     "geom:bbox":"8.806883,33.649842,9.390776,33.893646",
     "geom:latitude":33.769224,
     "geom:longitude":9.135315,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.KB.KN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307212,
-    "wof:geomhash":"f56802e64d946ab6730ef8e98294eb07",
+    "wof:geomhash":"02d4e9226bdb3b1ddf7552362d6533b6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757435,
-    "wof:lastmodified":1627522830,
+    "wof:lastmodified":1695886540,
     "wof:name":"Kebili Nord",
     "wof:parent_id":85679187,
     "wof:placetype":"county",

--- a/data/110/875/743/7/1108757437.geojson
+++ b/data/110/875/743/7/1108757437.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.116486,
-    "geom:area_square_m":1199324390.741067,
+    "geom:area_square_m":1199324575.668457,
     "geom:bbox":"8.587378,33.535473,9.537835,33.746841",
     "geom:latitude":33.628354,
     "geom:longitude":9.045631,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.KB.KS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307213,
-    "wof:geomhash":"db1c3254067460613ae149c0464161ec",
+    "wof:geomhash":"2021b055582e2637e7238d1a63352937",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757437,
-    "wof:lastmodified":1627522830,
+    "wof:lastmodified":1695886540,
     "wof:name":"Kebili Sud",
     "wof:parent_id":85679187,
     "wof:placetype":"county",

--- a/data/110/875/744/1/1108757441.geojson
+++ b/data/110/875/744/1/1108757441.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.252748,
-    "geom:area_square_m":2592691141.915938,
+    "geom:area_square_m":2592691480.231169,
     "geom:bbox":"8.368454,33.677469,9.345373,34.189483",
     "geom:latitude":33.943533,
     "geom:longitude":8.876121,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.KB.SA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307214,
-    "wof:geomhash":"9b4c35da4bf01698c85fe3bdcf7a4db6",
+    "wof:geomhash":"0acd0f8c78e215dfbc4eb0011ea3fbcc",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757441,
-    "wof:lastmodified":1627522834,
+    "wof:lastmodified":1695886548,
     "wof:name":"Souk El Ahad",
     "wof:parent_id":85679187,
     "wof:placetype":"county",

--- a/data/110/875/744/3/1108757443.geojson
+++ b/data/110/875/744/3/1108757443.geojson
@@ -84,9 +84,10 @@
     "wof:concordances":{
         "hasc:id":"TN.KF.DA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307215,
-    "wof:geomhash":"85c8dbd6a2dda0a807cdfd6caa8196d7",
+    "wof:geomhash":"5117946637d4d111ae0b35be2d9ce42e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":1108757443,
-    "wof:lastmodified":1566667266,
+    "wof:lastmodified":1695886583,
     "wof:name":"Dahmani",
     "wof:parent_id":85679131,
     "wof:placetype":"county",

--- a/data/110/875/744/5/1108757445.geojson
+++ b/data/110/875/744/5/1108757445.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.045528,
-    "geom:area_square_m":456429191.822558,
+    "geom:area_square_m":456429191.822557,
     "geom:bbox":"8.79931193778,35.6883117464,9.09829658634,35.9724552047",
     "geom:latitude":35.829971,
     "geom:longitude":8.956109,
@@ -75,9 +75,10 @@
     "wof:concordances":{
         "hasc:id":"TN.KF.KU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307216,
-    "wof:geomhash":"f46eca23f729162a42b64254c81293a3",
+    "wof:geomhash":"a170b292f8837d12c407150f0758baa2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -87,7 +88,7 @@
         }
     ],
     "wof:id":1108757445,
-    "wof:lastmodified":1566667266,
+    "wof:lastmodified":1695886583,
     "wof:name":"El Ksour",
     "wof:parent_id":85679131,
     "wof:placetype":"county",

--- a/data/110/875/744/7/1108757447.geojson
+++ b/data/110/875/744/7/1108757447.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.043146,
-    "geom:area_square_m":431309339.180528,
+    "geom:area_square_m":431309553.50905,
     "geom:bbox":"8.767514,35.938185,9.16197,36.178707",
     "geom:latitude":36.056325,
     "geom:longitude":9.004685,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.KF.ES"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307218,
-    "wof:geomhash":"40a900fd168d8bfce419b5d2900c8a1c",
+    "wof:geomhash":"6bbe56d9b6aaeecea8afec6df0d4e851",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757447,
-    "wof:lastmodified":1627522833,
+    "wof:lastmodified":1695886546,
     "wof:name":"Es-Sers",
     "wof:parent_id":85679131,
     "wof:placetype":"county",

--- a/data/110/875/744/9/1108757449.geojson
+++ b/data/110/875/744/9/1108757449.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017886,
-    "geom:area_square_m":179336336.815027,
+    "geom:area_square_m":179336526.633499,
     "geom:bbox":"8.535128,35.73946,8.752343,35.883255",
     "geom:latitude":35.819199,
     "geom:longitude":8.649126,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.KF.JE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307219,
-    "wof:geomhash":"7e57aefe2f3a5ce53168ecaf4921023d",
+    "wof:geomhash":"0f9f442386370d79e39b02fe9d663d60",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757449,
-    "wof:lastmodified":1627522829,
+    "wof:lastmodified":1695886538,
     "wof:name":"Jerissa",
     "wof:parent_id":85679131,
     "wof:placetype":"county",

--- a/data/110/875/745/1/1108757451.geojson
+++ b/data/110/875/745/1/1108757451.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019896,
-    "geom:area_square_m":199754465.408601,
+    "geom:area_square_m":199754304.469028,
     "geom:bbox":"8.420723,35.637998,8.627546,35.809642",
     "geom:latitude":35.712511,
     "geom:longitude":8.535273,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.KF.KR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307220,
-    "wof:geomhash":"9573cd3932e0865f65b94f0afc65f7c4",
+    "wof:geomhash":"352ae11476ee9dd226be59261a7c9e66",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757451,
-    "wof:lastmodified":1627522830,
+    "wof:lastmodified":1695886540,
     "wof:name":"Kal\u00e0a Kesba",
     "wof:parent_id":85679131,
     "wof:placetype":"county",

--- a/data/110/875/745/3/1108757453.geojson
+++ b/data/110/875/745/3/1108757453.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.051342,
-    "geom:area_square_m":514915074.456204,
+    "geom:area_square_m":514914937.837103,
     "geom:bbox":"8.253129,35.614258,8.555998,35.972205",
     "geom:latitude":35.798973,
     "geom:longitude":8.3697,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.KF.KS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307221,
-    "wof:geomhash":"84d58404db82dd9777d549df9a0f759e",
+    "wof:geomhash":"4bc3d8bdf8ef245dde5e90370802bcaa",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757453,
-    "wof:lastmodified":1627522830,
+    "wof:lastmodified":1695886540,
     "wof:name":"Kal\u00e0a Senan",
     "wof:parent_id":85679131,
     "wof:placetype":"county",

--- a/data/110/875/745/5/1108757455.geojson
+++ b/data/110/875/745/5/1108757455.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.039654,
-    "geom:area_square_m":395791386.655712,
+    "geom:area_square_m":395791373.163722,
     "geom:bbox":"8.70073,36.082825,9.045626,36.27778",
     "geom:latitude":36.176951,
     "geom:longitude":8.872249,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.KF.KE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307222,
-    "wof:geomhash":"8609a3d970c43f7953c2d375bb08b942",
+    "wof:geomhash":"56677c6eaf84bf2ac634cce2462d4660",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757455,
-    "wof:lastmodified":1627522830,
+    "wof:lastmodified":1695886540,
     "wof:name":"Kef Est",
     "wof:parent_id":85679131,
     "wof:placetype":"county",

--- a/data/110/875/745/9/1108757459.geojson
+++ b/data/110/875/745/9/1108757459.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.021286,
-    "geom:area_square_m":212548860.091639,
+    "geom:area_square_m":212548996.6727,
     "geom:bbox":"8.499042,36.06667,8.731492,36.230138",
     "geom:latitude":36.14491,
     "geom:longitude":8.628692,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.KF.KO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307223,
-    "wof:geomhash":"b95ce9ba23f4250cf8a610f3fcd755e0",
+    "wof:geomhash":"1fa9b09b0bfd96bce0699548d64badfc",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757459,
-    "wof:lastmodified":1627522830,
+    "wof:lastmodified":1695886541,
     "wof:name":"Kef Ouest",
     "wof:parent_id":85679131,
     "wof:placetype":"county",

--- a/data/110/875/746/1/1108757461.geojson
+++ b/data/110/875/746/1/1108757461.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.079635,
-    "geom:area_square_m":793442769.799216,
+    "geom:area_square_m":793442769.799226,
     "geom:bbox":"8.50542077146,36.1816897492,8.97739537548,36.4442830539",
     "geom:latitude":36.315242,
     "geom:longitude":8.74033,
@@ -75,9 +75,10 @@
     "wof:concordances":{
         "hasc:id":"TN.KF.NE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307224,
-    "wof:geomhash":"3d87f77253a2d2eb3873ba42231c5f57",
+    "wof:geomhash":"491e8638797c8b5a36e4a57b34394e64",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -87,7 +88,7 @@
         }
     ],
     "wof:id":1108757461,
-    "wof:lastmodified":1566667252,
+    "wof:lastmodified":1695886580,
     "wof:name":"Nebeur",
     "wof:parent_id":85679131,
     "wof:placetype":"county",

--- a/data/110/875/746/3/1108757463.geojson
+++ b/data/110/875/746/3/1108757463.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.066095,
-    "geom:area_square_m":659772999.18426,
+    "geom:area_square_m":659772999.184268,
     "geom:bbox":"8.29103926814,35.9571545533,8.57468823702,36.3751427727",
     "geom:latitude":36.168567,
     "geom:longitude":8.423044,
@@ -78,9 +78,10 @@
     "wof:concordances":{
         "hasc:id":"TN.KF.SS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307226,
-    "wof:geomhash":"609cae164dcc1e8099e20a41e9fffef0",
+    "wof:geomhash":"f9071705273c42b8dc1f2aad33a330a9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1108757463,
-    "wof:lastmodified":1566667252,
+    "wof:lastmodified":1695886580,
     "wof:name":"Sakiet Sidi Youssef",
     "wof:parent_id":85679131,
     "wof:placetype":"county",

--- a/data/110/875/746/5/1108757465.geojson
+++ b/data/110/875/746/5/1108757465.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.072071,
-    "geom:area_square_m":721332199.760096,
+    "geom:area_square_m":721332124.207477,
     "geom:bbox":"8.37117,35.815046,8.733936,36.114761",
     "geom:latitude":35.96036,
     "geom:longitude":8.55217,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.KF.TE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307227,
-    "wof:geomhash":"514ae9a8b2fcf9d16bd6dda8c6ab1344",
+    "wof:geomhash":"45932c3f937ccf239614a7b2e19b1bbe",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757465,
-    "wof:lastmodified":1627522834,
+    "wof:lastmodified":1695886548,
     "wof:name":"Tajerouin",
     "wof:parent_id":85679131,
     "wof:placetype":"county",

--- a/data/110/875/746/7/1108757467.geojson
+++ b/data/110/875/746/7/1108757467.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.0192,
-    "geom:area_square_m":193452997.870366,
+    "geom:area_square_m":193452824.80399,
     "geom:bbox":"10.565115,35.353579,10.848262,35.488011",
     "geom:latitude":35.427923,
     "geom:longitude":10.690202,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.MH.BO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307228,
-    "wof:geomhash":"26e222fd741b3ba009ec88f739987c72",
+    "wof:geomhash":"bc1dac7dae9214cb37db122c450f01a1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757467,
-    "wof:lastmodified":1627522825,
+    "wof:lastmodified":1695886532,
     "wof:name":"Bou Merdas",
     "wof:parent_id":85679161,
     "wof:placetype":"county",

--- a/data/110/875/746/9/1108757469.geojson
+++ b/data/110/875/746/9/1108757469.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012516,
-    "geom:area_square_m":126417083.597124,
+    "geom:area_square_m":126416865.015797,
     "geom:bbox":"10.980715,35.159548,11.162861,35.288816",
     "geom:latitude":35.230809,
     "geom:longitude":11.060354,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.MH.CB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307230,
-    "wof:geomhash":"51ec910d71557ac29984f986da7f7631",
+    "wof:geomhash":"f52816b528dde15d18c12257eeb49ec9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757469,
-    "wof:lastmodified":1627522830,
+    "wof:lastmodified":1695886541,
     "wof:name":"Cebba",
     "wof:parent_id":85679161,
     "wof:placetype":"county",

--- a/data/110/875/747/1/1108757471.geojson
+++ b/data/110/875/747/1/1108757471.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.043868,
-    "geom:area_square_m":443178687.544358,
+    "geom:area_square_m":443178687.544339,
     "geom:bbox":"10.2639188347,35.0853714147,10.5774592144,35.3500986949",
     "geom:latitude":35.213513,
     "geom:longitude":10.422236,
@@ -78,9 +78,10 @@
     "wof:concordances":{
         "hasc:id":"TN.MH.CR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307231,
-    "wof:geomhash":"0a841e09a31ccc2d70d5999f49c14bda",
+    "wof:geomhash":"e4fe579ce30e357e462d4ce07cb8f5a4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1108757471,
-    "wof:lastmodified":1566667248,
+    "wof:lastmodified":1695886579,
     "wof:name":"chorbane",
     "wof:parent_id":85679161,
     "wof:placetype":"county",

--- a/data/110/875/747/3/1108757473.geojson
+++ b/data/110/875/747/3/1108757473.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.029702,
-    "geom:area_square_m":299743431.395297,
+    "geom:area_square_m":299743451.323764,
     "geom:bbox":"10.585054,35.213233,10.850363,35.404085",
     "geom:latitude":35.299216,
     "geom:longitude":10.715737,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.MH.JE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307232,
-    "wof:geomhash":"c36b1d625ef224e47b90f5bb6cd67698",
+    "wof:geomhash":"f3d37521d0d05c0377121850c3576ac2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757473,
-    "wof:lastmodified":1627522827,
+    "wof:lastmodified":1695886535,
     "wof:name":"El Jam",
     "wof:parent_id":85679161,
     "wof:placetype":"county",

--- a/data/110/875/747/7/1108757477.geojson
+++ b/data/110/875/747/7/1108757477.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.032685,
-    "geom:area_square_m":329960334.959846,
+    "geom:area_square_m":329960209.043777,
     "geom:bbox":"10.163154,35.129373,10.387879,35.414336",
     "geom:latitude":35.271063,
     "geom:longitude":10.262132,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.MH.HB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307233,
-    "wof:geomhash":"405f548bbaf7e559bf9e957ff02fde8e",
+    "wof:geomhash":"994e71dce5b791f4382cdf7873ba775f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757477,
-    "wof:lastmodified":1627522829,
+    "wof:lastmodified":1695886538,
     "wof:name":"Hbira",
     "wof:parent_id":85679161,
     "wof:placetype":"county",

--- a/data/110/875/747/9/1108757479.geojson
+++ b/data/110/875/747/9/1108757479.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.023096,
-    "geom:area_square_m":232897053.943456,
+    "geom:area_square_m":232897143.99898,
     "geom:bbox":"10.8618,35.246059,11.078421,35.454486",
     "geom:latitude":35.362963,
     "geom:longitude":10.977833,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.MH.KE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307234,
-    "wof:geomhash":"8a8af5e32989b7f2aee84c1b419d8a8d",
+    "wof:geomhash":"36f68d56116bbd71ef4f7a969875065e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757479,
-    "wof:lastmodified":1627522830,
+    "wof:lastmodified":1695886541,
     "wof:name":"ksour Essaf",
     "wof:parent_id":85679161,
     "wof:placetype":"county",

--- a/data/110/875/748/1/1108757481.geojson
+++ b/data/110/875/748/1/1108757481.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016689,
-    "geom:area_square_m":168028767.357096,
+    "geom:area_square_m":168028844.875459,
     "geom:bbox":"10.838112,35.42074,11.084583,35.551895",
     "geom:latitude":35.486486,
     "geom:longitude":10.962504,
@@ -159,9 +159,10 @@
     "wof:concordances":{
         "hasc:id":"TN.MH.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307236,
-    "wof:geomhash":"bbea2f7fd509361dddb9a769a6950857",
+    "wof:geomhash":"27b8a25ef6499fbd930bb30d171594cd",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -171,7 +172,7 @@
         }
     ],
     "wof:id":1108757481,
-    "wof:lastmodified":1636495671,
+    "wof:lastmodified":1695886660,
     "wof:name":"Mahdia",
     "wof:parent_id":85679161,
     "wof:placetype":"county",

--- a/data/110/875/748/3/1108757483.geojson
+++ b/data/110/875/748/3/1108757483.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015597,
-    "geom:area_square_m":157658514.330223,
+    "geom:area_square_m":157658500.26374,
     "geom:bbox":"10.89973,35.088147,11.085449,35.260581",
     "geom:latitude":35.168184,
     "geom:longitude":10.978065,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.MH.ME"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307237,
-    "wof:geomhash":"1bbe054e82282fe068bad3960b89f3ed",
+    "wof:geomhash":"553cf6d413b00d0d9f4eb3968fdfd111",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757483,
-    "wof:lastmodified":1627522831,
+    "wof:lastmodified":1695886542,
     "wof:name":"Melloulech",
     "wof:parent_id":85679161,
     "wof:placetype":"county",

--- a/data/110/875/748/5/1108757485.geojson
+++ b/data/110/875/748/5/1108757485.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.031029,
-    "geom:area_square_m":312543292.315427,
+    "geom:area_square_m":312543185.638719,
     "geom:bbox":"10.1885,35.363391,10.46319,35.581521",
     "geom:latitude":35.45344,
     "geom:longitude":10.310831,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.MH.OC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307238,
-    "wof:geomhash":"ca923e9fc5a12b0618f8e5cfed4891ef",
+    "wof:geomhash":"d00ffbeb8bbeacb835b09d8d4296bf70",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757485,
-    "wof:lastmodified":1627522832,
+    "wof:lastmodified":1695886545,
     "wof:name":"Oueled Chamekh",
     "wof:parent_id":85679161,
     "wof:placetype":"county",

--- a/data/110/875/748/7/1108757487.geojson
+++ b/data/110/875/748/7/1108757487.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.028668,
-    "geom:area_square_m":289336653.570112,
+    "geom:area_square_m":289336653.570129,
     "geom:bbox":"10.7913516289,35.1429473773,10.9541379143,35.4247114896",
     "geom:latitude":35.291111,
     "geom:longitude":10.870968,
@@ -78,9 +78,10 @@
     "wof:concordances":{
         "hasc:id":"TN.MH.SA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307239,
-    "wof:geomhash":"239c60f80a8b6c38d6103b7abcde35bf",
+    "wof:geomhash":"c98f947c08a5fd1ac8c8d12600b8e7e4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1108757487,
-    "wof:lastmodified":1566667251,
+    "wof:lastmodified":1695886580,
     "wof:name":"Sidi Alouane",
     "wof:parent_id":85679161,
     "wof:placetype":"county",

--- a/data/110/875/748/9/1108757489.geojson
+++ b/data/110/875/748/9/1108757489.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.035689,
-    "geom:area_square_m":359970117.96563,
+    "geom:area_square_m":359970281.921365,
     "geom:bbox":"10.381719,35.210714,10.668998,35.448288",
     "geom:latitude":35.343266,
     "geom:longitude":10.517116,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.MH.SO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307240,
-    "wof:geomhash":"f4903d28314afc11310ef25c3fc38b79",
+    "wof:geomhash":"16df7064b149ce4cc86061c31f84e4f1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757489,
-    "wof:lastmodified":1627522827,
+    "wof:lastmodified":1695886535,
     "wof:name":"souassi",
     "wof:parent_id":85679161,
     "wof:placetype":"county",

--- a/data/110/875/749/1/1108757491.geojson
+++ b/data/110/875/749/1/1108757491.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017454,
-    "geom:area_square_m":173098397.198054,
+    "geom:area_square_m":173098397.198053,
     "geom:bbox":"9.7683965948,36.5827651021,9.92145728119,36.7478672275",
     "geom:latitude":36.675107,
     "geom:longitude":9.85014,
@@ -78,9 +78,10 @@
     "wof:concordances":{
         "hasc:id":"TN.MN.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307242,
-    "wof:geomhash":"1ca4f2a013078457ee5542346662a6b7",
+    "wof:geomhash":"2d46c98825d0b756c77ce708d31f0cb9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1108757491,
-    "wof:lastmodified":1566667249,
+    "wof:lastmodified":1695886580,
     "wof:name":"Borj El Amri",
     "wof:parent_id":85679099,
     "wof:placetype":"county",

--- a/data/110/875/749/5/1108757495.geojson
+++ b/data/110/875/749/5/1108757495.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000764,
-    "geom:area_square_m":7564418.145288,
+    "geom:area_square_m":7564418.145289,
     "geom:bbox":"10.0712106931,36.8148863759,10.1054005411,36.8552893011",
     "geom:latitude":36.829751,
     "geom:longitude":10.084672,
@@ -84,9 +84,10 @@
     "wof:concordances":{
         "hasc:id":"TN.MN.DH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307243,
-    "wof:geomhash":"d9f12b674cfa55c305b53b87e3236124",
+    "wof:geomhash":"b8ca22d7ade92d174354348c75fdd969",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":1108757495,
-    "wof:lastmodified":1566667249,
+    "wof:lastmodified":1695886580,
     "wof:name":"Douar Hicher",
     "wof:parent_id":85679099,
     "wof:placetype":"county",

--- a/data/110/875/749/7/1108757497.geojson
+++ b/data/110/875/749/7/1108757497.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015522,
-    "geom:area_square_m":153741452.350101,
+    "geom:area_square_m":153741452.350109,
     "geom:bbox":"9.62128293033,36.7159912105,9.87289151136,36.8194573052",
     "geom:latitude":36.771558,
     "geom:longitude":9.764379,
@@ -75,9 +75,10 @@
     "wof:concordances":{
         "hasc:id":"TN.MN.BT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307244,
-    "wof:geomhash":"4414cde3ba96c13da9bd70b60ecc250b",
+    "wof:geomhash":"5546235884542b6031fbf0f5bdfd4a22",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -87,7 +88,7 @@
         }
     ],
     "wof:id":1108757497,
-    "wof:lastmodified":1566667249,
+    "wof:lastmodified":1695886580,
     "wof:name":"El Battan",
     "wof:parent_id":85679099,
     "wof:placetype":"county",

--- a/data/110/875/749/9/1108757499.geojson
+++ b/data/110/875/749/9/1108757499.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018994,
-    "geom:area_square_m":187912712.550183,
+    "geom:area_square_m":187912724.578881,
     "geom:bbox":"9.850319,36.744317,10.00273,36.953615",
     "geom:latitude":36.860742,
     "geom:longitude":9.91821,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.MN.JE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307245,
-    "wof:geomhash":"1ef648ffa69ece6da85debfffad331cf",
+    "wof:geomhash":"aa8165d40ddcd147aebf11c22905ae87",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757499,
-    "wof:lastmodified":1627522826,
+    "wof:lastmodified":1695886533,
     "wof:name":"Jedaida",
     "wof:parent_id":85679099,
     "wof:placetype":"county",

--- a/data/110/875/750/1/1108757501.geojson
+++ b/data/110/875/750/1/1108757501.geojson
@@ -123,9 +123,10 @@
     "wof:concordances":{
         "hasc:id":"TN.MN.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307246,
-    "wof:geomhash":"7d8d9a2f0562d7b0b93d48abb3041375",
+    "wof:geomhash":"fc9cad7c6e8bd56aadb6d6b80c7982fd",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1108757501,
-    "wof:lastmodified":1566667262,
+    "wof:lastmodified":1695886581,
     "wof:name":"Manouba",
     "wof:parent_id":85679099,
     "wof:placetype":"county",

--- a/data/110/875/750/3/1108757503.geojson
+++ b/data/110/875/750/3/1108757503.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.024745,
-    "geom:area_square_m":245341480.314895,
+    "geom:area_square_m":245341480.314893,
     "geom:bbox":"9.87851777471,36.5877741329,10.0918379121,36.7983501423",
     "geom:latitude":36.695181,
     "geom:longitude":9.979859,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"TN.MN.MO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307248,
-    "wof:geomhash":"af1e5513a0f301561ce6b95d6dc49ae1",
+    "wof:geomhash":"2d13f64e1239103f56b743d660ae31d8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1108757503,
-    "wof:lastmodified":1566667262,
+    "wof:lastmodified":1695886581,
     "wof:name":"Mornaguia",
     "wof:parent_id":85679099,
     "wof:placetype":"county",

--- a/data/110/875/750/5/1108757505.geojson
+++ b/data/110/875/750/5/1108757505.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006661,
-    "geom:area_square_m":65936336.899848,
+    "geom:area_square_m":65936347.336854,
     "geom:bbox":"9.957385,36.782559,10.07955,36.873372",
     "geom:latitude":36.823795,
     "geom:longitude":10.024138,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.MN.OE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307249,
-    "wof:geomhash":"b1bc24c92648d18d7538e42e312fbac9",
+    "wof:geomhash":"5436b3c5e2a227c111c94af7aa7bfee4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757505,
-    "wof:lastmodified":1627522832,
+    "wof:lastmodified":1695886545,
     "wof:name":"Oued Ellili",
     "wof:parent_id":85679099,
     "wof:placetype":"county",

--- a/data/110/875/750/7/1108757507.geojson
+++ b/data/110/875/750/7/1108757507.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.027873,
-    "geom:area_square_m":275784731.371428,
+    "geom:area_square_m":275784731.371432,
     "geom:bbox":"9.56462923769,36.7728760428,9.89066483097,36.9675164107",
     "geom:latitude":36.853035,
     "geom:longitude":9.742619,
@@ -78,9 +78,10 @@
     "wof:concordances":{
         "hasc:id":"TN.MN.TE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307250,
-    "wof:geomhash":"915774281d8fc06ec8d1cd7836fe511c",
+    "wof:geomhash":"4ff92bddd5bf802bb493a438e99e23a1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1108757507,
-    "wof:lastmodified":1566667262,
+    "wof:lastmodified":1695886581,
     "wof:name":"Tebourba",
     "wof:parent_id":85679099,
     "wof:placetype":"county",

--- a/data/110/875/750/9/1108757509.geojson
+++ b/data/110/875/750/9/1108757509.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.467245,
-    "geom:area_square_m":4851653164.492834,
+    "geom:area_square_m":4851653593.457208,
     "geom:bbox":"10.530561,32.26966,11.599217,33.377585",
     "geom:latitude":32.886509,
     "geom:longitude":11.205267,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.ME.BG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307251,
-    "wof:geomhash":"21b996e6a7f327768e0b6b8c62f9f0e6",
+    "wof:geomhash":"82275fd3ba9485b01f8e6f6339d9f19f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757509,
-    "wof:lastmodified":1627522824,
+    "wof:lastmodified":1695886530,
     "wof:name":"Ben Guerdane",
     "wof:parent_id":85679183,
     "wof:placetype":"county",

--- a/data/110/875/751/3/1108757513.geojson
+++ b/data/110/875/751/3/1108757513.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.130808,
-    "geom:area_square_m":1353024491.777277,
+    "geom:area_square_m":1353024752.84009,
     "geom:bbox":"9.717007,33.048165,10.446927,33.420543",
     "geom:latitude":33.226888,
     "geom:longitude":10.118146,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.ME.BK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307252,
-    "wof:geomhash":"0688fcbb42a1e161adc80c950645ae06",
+    "wof:geomhash":"d749d3c73382ac43526bf91aaa64343a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757513,
-    "wof:lastmodified":1627522824,
+    "wof:lastmodified":1695886530,
     "wof:name":"B\u00e9ni Khedeche",
     "wof:parent_id":85679183,
     "wof:placetype":"county",

--- a/data/110/875/751/5/1108757515.geojson
+++ b/data/110/875/751/5/1108757515.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013609,
-    "geom:area_square_m":139912995.33987,
+    "geom:area_square_m":139913131.082311,
     "geom:bbox":"10.729555,33.63039,10.910903,33.827422",
     "geom:latitude":33.750733,
     "geom:longitude":10.807956,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.ME.DA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307253,
-    "wof:geomhash":"3af4ef15629b3e372884141004dd282b",
+    "wof:geomhash":"1f3432937710861342004a76506a88a7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757515,
-    "wof:lastmodified":1627522826,
+    "wof:lastmodified":1695886533,
     "wof:name":"Jerba Ajim",
     "wof:parent_id":85679183,
     "wof:placetype":"county",

--- a/data/110/875/751/7/1108757517.geojson
+++ b/data/110/875/751/7/1108757517.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017361,
-    "geom:area_square_m":178290444.947918,
+    "geom:area_square_m":178290729.370968,
     "geom:bbox":"10.742888,33.785005,10.990173,33.902943",
     "geom:latitude":33.847844,
     "geom:longitude":10.855743,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.ME.DH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307254,
-    "wof:geomhash":"5a88005075dfd839acaa280d404f2a61",
+    "wof:geomhash":"f675889c2f91949ca094c09fd27217c3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757517,
-    "wof:lastmodified":1627522826,
+    "wof:lastmodified":1695886533,
     "wof:name":"Jerba Houmet Souk",
     "wof:parent_id":85679183,
     "wof:placetype":"county",

--- a/data/110/875/751/9/1108757519.geojson
+++ b/data/110/875/751/9/1108757519.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019042,
-    "geom:area_square_m":195727450.738979,
+    "geom:area_square_m":195727236.991525,
     "geom:bbox":"10.854256,33.676084,11.061139,33.855245",
     "geom:latitude":33.769781,
     "geom:longitude":10.955475,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.ME.DM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307255,
-    "wof:geomhash":"6c536875fec28fc4c2ddd1b0cfe5c411",
+    "wof:geomhash":"bbb38663528c8951562dd82baec0b1f7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757519,
-    "wof:lastmodified":1627522826,
+    "wof:lastmodified":1695886533,
     "wof:name":"Jerba Midoun",
     "wof:parent_id":85679183,
     "wof:placetype":"county",

--- a/data/110/875/752/1/1108757521.geojson
+++ b/data/110/875/752/1/1108757521.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.07184,
-    "geom:area_square_m":741832454.863004,
+    "geom:area_square_m":741832345.542463,
     "geom:bbox":"10.448365,33.194279,10.770687,33.647694",
     "geom:latitude":33.373503,
     "geom:longitude":10.629485,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.ME.MN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307256,
-    "wof:geomhash":"a5105ba8fa778ea58705a7f93a28b035",
+    "wof:geomhash":"e1969946adafa86ff46c849a55e59c3c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757521,
-    "wof:lastmodified":1627522831,
+    "wof:lastmodified":1695886542,
     "wof:name":"Medenine Nord",
     "wof:parent_id":85679183,
     "wof:placetype":"county",

--- a/data/110/875/752/3/1108757523.geojson
+++ b/data/110/875/752/3/1108757523.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.031477,
-    "geom:area_square_m":325061137.964348,
+    "geom:area_square_m":325061301.566554,
     "geom:bbox":"10.255864,33.210725,10.515306,33.497643",
     "geom:latitude":33.366415,
     "geom:longitude":10.386233,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.ME.MS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307257,
-    "wof:geomhash":"8d230bc4225fab0b1a3395751a9b1435",
+    "wof:geomhash":"94a981770c62ee9d8735481350c896af",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757523,
-    "wof:lastmodified":1627522831,
+    "wof:lastmodified":1695886542,
     "wof:name":"Medenine Sud",
     "wof:parent_id":85679183,
     "wof:placetype":"county",

--- a/data/110/875/752/5/1108757525.geojson
+++ b/data/110/875/752/5/1108757525.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.064935,
-    "geom:area_square_m":669227889.631997,
+    "geom:area_square_m":669228153.21378,
     "geom:bbox":"10.340012,33.373553,10.74625,33.707111",
     "geom:latitude":33.542273,
     "geom:longitude":10.523572,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.ME.SM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307259,
-    "wof:geomhash":"536de6e2a71e401d8a806fccffe1713a",
+    "wof:geomhash":"c47336c456f6ccd606951506f7977148",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757525,
-    "wof:lastmodified":1627522833,
+    "wof:lastmodified":1695886546,
     "wof:name":"Sidi Maklouf",
     "wof:parent_id":85679183,
     "wof:placetype":"county",

--- a/data/110/875/752/7/1108757527.geojson
+++ b/data/110/875/752/7/1108757527.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.088151,
-    "geom:area_square_m":909561771.710673,
+    "geom:area_square_m":909561649.145508,
     "geom:bbox":"10.75433,33.277047,11.291774,33.639584",
     "geom:latitude":33.440234,
     "geom:longitude":10.979168,
@@ -147,9 +147,10 @@
     "wof:concordances":{
         "hasc:id":"TN.ME.ZA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307260,
-    "wof:geomhash":"1409f89a9b4dd19e84b3144ef64ab90c",
+    "wof:geomhash":"43afb93fb465e90febdaf995b7340264",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -159,7 +160,7 @@
         }
     ],
     "wof:id":1108757527,
-    "wof:lastmodified":1636495670,
+    "wof:lastmodified":1695886660,
     "wof:name":"Zarzis",
     "wof:parent_id":85679183,
     "wof:placetype":"county",

--- a/data/110/875/753/1/1108757531.geojson
+++ b/data/110/875/753/1/1108757531.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004926,
-    "geom:area_square_m":49522425.93285,
+    "geom:area_square_m":49522425.932847,
     "geom:bbox":"10.9737247194,35.5501322943,11.05038929,35.646251678",
     "geom:latitude":35.599173,
     "geom:longitude":11.010916,
@@ -90,9 +90,10 @@
     "wof:concordances":{
         "hasc:id":"TN.MS.BK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307261,
-    "wof:geomhash":"215c7e99be386b5d5c214851b2770f14",
+    "wof:geomhash":"f5903007d14bf3e238b2a11a5a91a671",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1108757531,
-    "wof:lastmodified":1566667241,
+    "wof:lastmodified":1695886578,
     "wof:name":"Bekalta",
     "wof:parent_id":85679165,
     "wof:placetype":"county",

--- a/data/110/875/753/3/1108757533.geojson
+++ b/data/110/875/753/3/1108757533.geojson
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"TN.MS.BM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307262,
-    "wof:geomhash":"be461769c394147f354a655cdbc0f0d4",
+    "wof:geomhash":"4e4fedc2293e97ae181ea67af1655a62",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1108757533,
-    "wof:lastmodified":1566667242,
+    "wof:lastmodified":1695886578,
     "wof:name":"Bembla",
     "wof:parent_id":85679165,
     "wof:placetype":"county",

--- a/data/110/875/753/5/1108757535.geojson
+++ b/data/110/875/753/5/1108757535.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010001,
-    "geom:area_square_m":100646818.908779,
+    "geom:area_square_m":100646847.514352,
     "geom:bbox":"10.639014,35.480999,10.841577,35.593091",
     "geom:latitude":35.525613,
     "geom:longitude":10.752607,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.MS.BH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307263,
-    "wof:geomhash":"e5f3d90561d5efdc91f4aeaadcaef3c4",
+    "wof:geomhash":"43991a7f308650a576933631cbe9fae7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757535,
-    "wof:lastmodified":1627522824,
+    "wof:lastmodified":1695886531,
     "wof:name":"B\u00e9ni Hassan",
     "wof:parent_id":85679165,
     "wof:placetype":"county",

--- a/data/110/875/753/7/1108757537.geojson
+++ b/data/110/875/753/7/1108757537.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015246,
-    "geom:area_square_m":153254800.011743,
+    "geom:area_square_m":153254797.911669,
     "geom:bbox":"10.577826,35.563002,10.817527,35.669755",
     "geom:latitude":35.616798,
     "geom:longitude":10.703076,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.MS.JA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307264,
-    "wof:geomhash":"ba11669a7f000381207d0583e929533e",
+    "wof:geomhash":"9aec4c4c5fb028a17cba946cecf6d9a7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757537,
-    "wof:lastmodified":1627522829,
+    "wof:lastmodified":1695886539,
     "wof:name":"Jammel",
     "wof:parent_id":85679165,
     "wof:placetype":"county",

--- a/data/110/875/753/9/1108757539.geojson
+++ b/data/110/875/753/9/1108757539.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002199,
-    "geom:area_square_m":22101443.817887,
+    "geom:area_square_m":22101333.557807,
     "geom:bbox":"10.842497,35.606484,10.910133,35.657435",
     "geom:latitude":35.634773,
     "geom:longitude":10.870598,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.MS.KH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307265,
-    "wof:geomhash":"945eebf5d3dda58b249f97b4e09f3182",
+    "wof:geomhash":"fc9dfc9a8f961571d8d9b4773ae1055e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757539,
-    "wof:lastmodified":1627522830,
+    "wof:lastmodified":1695886541,
     "wof:name":"Ksar Helal",
     "wof:parent_id":85679165,
     "wof:placetype":"county",

--- a/data/110/875/754/1/1108757541.geojson
+++ b/data/110/875/754/1/1108757541.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004372,
-    "geom:area_square_m":43927300.380392,
+    "geom:area_square_m":43927325.900905,
     "geom:bbox":"10.792231,35.589784,10.867035,35.702098",
     "geom:latitude":35.648662,
     "geom:longitude":10.82894,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.MS.KM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307266,
-    "wof:geomhash":"c40dca2114128340b68f2c0fb28fa42d",
+    "wof:geomhash":"72bd2164e64b1e3f0c32a97e4ceaaa3b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757541,
-    "wof:lastmodified":1627522830,
+    "wof:lastmodified":1695886541,
     "wof:name":"Ksibet El Medyouni",
     "wof:parent_id":85679165,
     "wof:placetype":"county",

--- a/data/110/875/754/3/1108757543.geojson
+++ b/data/110/875/754/3/1108757543.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.023996,
-    "geom:area_square_m":241445027.730795,
+    "geom:area_square_m":241445027.730788,
     "geom:bbox":"10.7333146655,35.4290404633,10.9961340834,35.6471201633",
     "geom:latitude":35.53793,
     "geom:longitude":10.872945,
@@ -93,9 +93,10 @@
     "wof:concordances":{
         "hasc:id":"TN.MS.MK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307267,
-    "wof:geomhash":"a39362b6707251671dde0c9f73866b88",
+    "wof:geomhash":"f11cb613dd320d2c4eb176774ddcdfc0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108757543,
-    "wof:lastmodified":1566667241,
+    "wof:lastmodified":1695886578,
     "wof:name":"Moknine",
     "wof:parent_id":85679165,
     "wof:placetype":"county",

--- a/data/110/875/754/5/1108757545.geojson
+++ b/data/110/875/754/5/1108757545.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007258,
-    "geom:area_square_m":72836715.565717,
+    "geom:area_square_m":72836652.404406,
     "geom:bbox":"10.681284,35.69871,11.047889,35.805416",
     "geom:latitude":35.749161,
     "geom:longitude":10.790784,
@@ -135,9 +135,10 @@
     "wof:concordances":{
         "hasc:id":"TN.MS.MS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307268,
-    "wof:geomhash":"76284b2e548b3a5921685b34b88916ba",
+    "wof:geomhash":"7ae4d83a213dc68b25f14aa6792d3737",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -147,7 +148,7 @@
         }
     ],
     "wof:id":1108757545,
-    "wof:lastmodified":1636495670,
+    "wof:lastmodified":1695886660,
     "wof:name":"Monastir",
     "wof:parent_id":85679165,
     "wof:placetype":"county",

--- a/data/110/875/754/9/1108757549.geojson
+++ b/data/110/875/754/9/1108757549.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004826,
-    "geom:area_square_m":48465768.559614,
+    "geom:area_square_m":48465846.765482,
     "geom:bbox":"10.632072,35.65874,10.726219,35.744896",
     "geom:latitude":35.697477,
     "geom:longitude":10.671537,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.MS.OU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307270,
-    "wof:geomhash":"a4891f84139e19678930074bc4d945b7",
+    "wof:geomhash":"2c224fef641f0a838f53599f17dc75b1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757549,
-    "wof:lastmodified":1627522832,
+    "wof:lastmodified":1695886545,
     "wof:name":"Ouerdanine",
     "wof:parent_id":85679165,
     "wof:placetype":"county",

--- a/data/110/875/755/1/1108757551.geojson
+++ b/data/110/875/755/1/1108757551.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004438,
-    "geom:area_square_m":44542230.995093,
+    "geom:area_square_m":44542181.819007,
     "geom:bbox":"10.659368,35.70156,10.765891,35.775531",
     "geom:latitude":35.734619,
     "geom:longitude":10.710409,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.MS.SA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307271,
-    "wof:geomhash":"7c692c414f156e554d304fddceda60da",
+    "wof:geomhash":"df3d4ec0b45bd54e47eab78f6f5cdd5b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757551,
-    "wof:lastmodified":1627522833,
+    "wof:lastmodified":1695886546,
     "wof:name":"Sahline",
     "wof:parent_id":85679165,
     "wof:placetype":"county",

--- a/data/110/875/755/3/1108757553.geojson
+++ b/data/110/875/755/3/1108757553.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001536,
-    "geom:area_square_m":15434887.696112,
+    "geom:area_square_m":15434967.444012,
     "geom:bbox":"10.857076,35.645817,10.934908,35.68375",
     "geom:latitude":35.663065,
     "geom:longitude":10.89412,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.MS.SL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307272,
-    "wof:geomhash":"f7dbdaa9a718854fa882e5c1b5f58e67",
+    "wof:geomhash":"d9184a0aa6486318b1699016adfd5742",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757553,
-    "wof:lastmodified":1627522833,
+    "wof:lastmodified":1695886546,
     "wof:name":"SayadaLamtaBouhjar",
     "wof:parent_id":85679165,
     "wof:placetype":"county",

--- a/data/110/875/755/5/1108757555.geojson
+++ b/data/110/875/755/5/1108757555.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001892,
-    "geom:area_square_m":19013738.380887,
+    "geom:area_square_m":19013754.297331,
     "geom:bbox":"10.928295,35.615036,10.989496,35.663723",
     "geom:latitude":35.64028,
     "geom:longitude":10.958435,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.MS.TE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307273,
-    "wof:geomhash":"02ca6e8f702c2ab73486fb0cd2eea09e",
+    "wof:geomhash":"f3793ed1a054261b9b9dc520bee0a9be",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757555,
-    "wof:lastmodified":1627522835,
+    "wof:lastmodified":1695886551,
     "wof:name":"Teboulba",
     "wof:parent_id":85679165,
     "wof:placetype":"county",

--- a/data/110/875/755/7/1108757557.geojson
+++ b/data/110/875/755/7/1108757557.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018905,
-    "geom:area_square_m":190221284.457331,
+    "geom:area_square_m":190221426.851345,
     "geom:bbox":"10.494583,35.476163,10.776453,35.601939",
     "geom:latitude":35.539735,
     "geom:longitude":10.622945,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.MS.ZA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307274,
-    "wof:geomhash":"a522c2e862768426f6f289684fa5712b",
+    "wof:geomhash":"a5ec117cd653619b6b30b92e4bdbb644",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757557,
-    "wof:lastmodified":1627522835,
+    "wof:lastmodified":1695886551,
     "wof:name":"Zarmedine",
     "wof:parent_id":85679165,
     "wof:placetype":"county",

--- a/data/110/875/755/9/1108757559.geojson
+++ b/data/110/875/755/9/1108757559.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013961,
-    "geom:area_square_m":138727273.698643,
+    "geom:area_square_m":138727273.698644,
     "geom:bbox":"10.4865397873,36.4598192006,10.6541089151,36.5910333141",
     "geom:latitude":36.526035,
     "geom:longitude":10.578814,
@@ -75,9 +75,10 @@
     "wof:concordances":{
         "hasc:id":"TN.NB.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307275,
-    "wof:geomhash":"9b6741c68e807900cc53e9f4784e129b",
+    "wof:geomhash":"99fa05f96873c220c6256bbb471d3bf4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -87,7 +88,7 @@
         }
     ],
     "wof:id":1108757559,
-    "wof:lastmodified":1566667237,
+    "wof:lastmodified":1695886577,
     "wof:name":"Bou Argoub",
     "wof:parent_id":85679119,
     "wof:placetype":"county",

--- a/data/110/875/756/1/1108757561.geojson
+++ b/data/110/875/756/1/1108757561.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011666,
-    "geom:area_square_m":115769040.181398,
+    "geom:area_square_m":115769159.01204,
     "geom:bbox":"10.523834,36.579205,10.73449,36.666101",
     "geom:latitude":36.625707,
     "geom:longitude":10.630385,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.NB.BD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307276,
-    "wof:geomhash":"f9dbf31221ba979b8e9a213bf5ce6f46",
+    "wof:geomhash":"3a6e6f0f858f6a83af7c590799c50c10",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757561,
-    "wof:lastmodified":1627522824,
+    "wof:lastmodified":1695886531,
     "wof:name":"B\u00e9ni Kalled",
     "wof:parent_id":85679119,
     "wof:placetype":"county",

--- a/data/110/875/756/3/1108757563.geojson
+++ b/data/110/875/756/3/1108757563.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011981,
-    "geom:area_square_m":119053890.084576,
+    "geom:area_square_m":119053890.08458,
     "geom:bbox":"10.687725934,36.4507262104,10.8366107948,36.5890408736",
     "geom:latitude":36.52562,
     "geom:longitude":10.76715,
@@ -78,9 +78,10 @@
     "wof:concordances":{
         "hasc:id":"TN.NB.BR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307277,
-    "wof:geomhash":"6ade7d83b0945b739c1e650c9b8ff702",
+    "wof:geomhash":"79df56e84d28b9623e4a26782714bb70",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1108757563,
-    "wof:lastmodified":1566667258,
+    "wof:lastmodified":1695886581,
     "wof:name":"B\u00e9ni Khiar",
     "wof:parent_id":85679119,
     "wof:placetype":"county",

--- a/data/110/875/756/7/1108757567.geojson
+++ b/data/110/875/756/7/1108757567.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006042,
-    "geom:area_square_m":60042797.30082,
+    "geom:area_square_m":60042740.535033,
     "geom:bbox":"10.634312,36.442878,10.769244,36.58558",
     "geom:latitude":36.520681,
     "geom:longitude":10.69738,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.NB.DC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307278,
-    "wof:geomhash":"9a69654af1c475a749c3f6e9f25fc454",
+    "wof:geomhash":"df9512445040adf30cc30830fe808ba8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757567,
-    "wof:lastmodified":1627522825,
+    "wof:lastmodified":1695886532,
     "wof:name":"Dar Ch\u00e0aban Elfehri",
     "wof:parent_id":85679119,
     "wof:placetype":"county",

--- a/data/110/875/756/9/1108757569.geojson
+++ b/data/110/875/756/9/1108757569.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.031926,
-    "geom:area_square_m":317622682.064689,
+    "geom:area_square_m":317622567.606824,
     "geom:bbox":"10.345979,36.352813,10.681707,36.50894",
     "geom:latitude":36.431724,
     "geom:longitude":10.489387,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.NB.HM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307279,
-    "wof:geomhash":"1e9f5784b0e15b9821b2a0a807789d9f",
+    "wof:geomhash":"ebba547b1e4cfbe9f070bcb83182155f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757569,
-    "wof:lastmodified":1627522826,
+    "wof:lastmodified":1695886534,
     "wof:name":"El Hammamet",
     "wof:parent_id":85679119,
     "wof:placetype":"county",

--- a/data/110/875/757/1/1108757571.geojson
+++ b/data/110/875/757/1/1108757571.geojson
@@ -75,9 +75,10 @@
     "wof:concordances":{
         "hasc:id":"TN.NB.MI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307280,
-    "wof:geomhash":"72dc7afae41d616ba87eb18a4a5000ef",
+    "wof:geomhash":"4fa26c2af2243fef4b67ad0dba072293",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -87,7 +88,7 @@
         }
     ],
     "wof:id":1108757571,
-    "wof:lastmodified":1566667262,
+    "wof:lastmodified":1695886582,
     "wof:name":"El Mida",
     "wof:parent_id":85679119,
     "wof:placetype":"county",

--- a/data/110/875/757/3/1108757573.geojson
+++ b/data/110/875/757/3/1108757573.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.029761,
-    "geom:area_square_m":295494179.635313,
+    "geom:area_square_m":295494112.890088,
     "geom:bbox":"10.344663,36.483076,10.578643,36.700796",
     "geom:latitude":36.586374,
     "geom:longitude":10.444509,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.NB.GR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307282,
-    "wof:geomhash":"c165681c744de92b1545c649c0a89f79",
+    "wof:geomhash":"dd7aca718fcfa7d83ce2ab54a0a57167",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757573,
-    "wof:lastmodified":1627522828,
+    "wof:lastmodified":1695886537,
     "wof:name":"Grambalia",
     "wof:parent_id":85679119,
     "wof:placetype":"county",

--- a/data/110/875/757/5/1108757575.geojson
+++ b/data/110/875/757/5/1108757575.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008094,
-    "geom:area_square_m":80016588.887407,
+    "geom:area_square_m":80016524.254628,
     "geom:bbox":"11.010838,36.855215,11.137889,36.984115",
     "geom:latitude":36.918861,
     "geom:longitude":11.074944,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.NB.HG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307284,
-    "wof:geomhash":"2896428d419d9faf43cf862a64c9378e",
+    "wof:geomhash":"91654c088e835397106f6fcee379ac33",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757575,
-    "wof:lastmodified":1627522828,
+    "wof:lastmodified":1695886537,
     "wof:name":"Hammam Laghzaz",
     "wof:parent_id":85679119,
     "wof:placetype":"county",

--- a/data/110/875/757/7/1108757577.geojson
+++ b/data/110/875/757/7/1108757577.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.03605,
-    "geom:area_square_m":356219979.520327,
+    "geom:area_square_m":356219845.606021,
     "geom:bbox":"10.761673,36.808736,11.080929,37.089584",
     "geom:latitude":36.953614,
     "geom:longitude":10.920461,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.NB.HR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307285,
-    "wof:geomhash":"a88c6ad0440f49858f9b43eb0299b416",
+    "wof:geomhash":"20df1120dfc2346c79866d6d9c28d1ec",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757577,
-    "wof:lastmodified":1627522826,
+    "wof:lastmodified":1695886534,
     "wof:name":"Haouaria",
     "wof:parent_id":85679119,
     "wof:placetype":"county",

--- a/data/110/875/757/9/1108757579.geojson
+++ b/data/110/875/757/9/1108757579.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012558,
-    "geom:area_square_m":124217542.84178,
+    "geom:area_square_m":124217542.841789,
     "geom:bbox":"10.9341009602,36.7923068584,11.1294658721,36.9519459637",
     "geom:latitude":36.87554,
     "geom:longitude":11.022768,
@@ -123,9 +123,10 @@
     "wof:concordances":{
         "hasc:id":"TN.NB.KE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307286,
-    "wof:geomhash":"243a436fb8d34953d8119eb4f558e01e",
+    "wof:geomhash":"27d2949e8ca7b02c49cafa892a2478ef",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1108757579,
-    "wof:lastmodified":1566667262,
+    "wof:lastmodified":1695886582,
     "wof:name":"Kelibia",
     "wof:parent_id":85679119,
     "wof:placetype":"county",

--- a/data/110/875/758/1/1108757581.geojson
+++ b/data/110/875/758/1/1108757581.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.020298,
-    "geom:area_square_m":201454026.660315,
+    "geom:area_square_m":201454026.660319,
     "geom:bbox":"10.6923946726,36.5113700277,10.9156916225,36.6960153538",
     "geom:latitude":36.618311,
     "geom:longitude":10.806159,
@@ -87,9 +87,10 @@
     "wof:concordances":{
         "hasc:id":"TN.NB.KO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307287,
-    "wof:geomhash":"f0b82ff81e8d45c00e70cc2945a61be4",
+    "wof:geomhash":"3c84ff043952c386418f8be4284935f7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":1108757581,
-    "wof:lastmodified":1566667257,
+    "wof:lastmodified":1695886581,
     "wof:name":"Korba",
     "wof:parent_id":85679119,
     "wof:placetype":"county",

--- a/data/110/875/758/5/1108757585.geojson
+++ b/data/110/875/758/5/1108757585.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014221,
-    "geom:area_square_m":140996623.347233,
+    "geom:area_square_m":140996485.085279,
     "geom:bbox":"10.551303,36.651498,10.774277,36.761602",
     "geom:latitude":36.696558,
     "geom:longitude":10.668951,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.NB.MB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307288,
-    "wof:geomhash":"8dadd638010fe9ba92dc7a892cdc5d96",
+    "wof:geomhash":"e6d8612fe9af950e2bdc44bd924585c0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757585,
-    "wof:lastmodified":1627522831,
+    "wof:lastmodified":1695886543,
     "wof:name":"Menzil Bou Zelfa",
     "wof:parent_id":85679119,
     "wof:placetype":"county",

--- a/data/110/875/758/7/1108757587.geojson
+++ b/data/110/875/758/7/1108757587.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.024971,
-    "geom:area_square_m":247242325.485406,
+    "geom:area_square_m":247242470.198654,
     "geom:bbox":"10.765232,36.705721,11.030184,36.897542",
     "geom:latitude":36.800356,
     "geom:longitude":10.918785,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.NB.MT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307290,
-    "wof:geomhash":"2744aa0f143bf7f6f590241fe9c25da5",
+    "wof:geomhash":"50da616b62c1ce388d22b8b4d03021ea",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757587,
-    "wof:lastmodified":1627522832,
+    "wof:lastmodified":1695886545,
     "wof:name":"Menzil Temime",
     "wof:parent_id":85679119,
     "wof:placetype":"county",

--- a/data/110/875/758/9/1108757589.geojson
+++ b/data/110/875/758/9/1108757589.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007196,
-    "geom:area_square_m":71516640.37955,
+    "geom:area_square_m":71516615.880143,
     "geom:bbox":"10.616393,36.422562,10.820397,37.143749",
     "geom:latitude":36.511987,
     "geom:longitude":10.685635,
@@ -165,9 +165,10 @@
     "wof:concordances":{
         "hasc:id":"TN.NB.NA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307291,
-    "wof:geomhash":"2491a26fdfb1b3a30ffe5b2280531ff2",
+    "wof:geomhash":"83345861ff5f6b2e7df37a512b86534a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -177,7 +178,7 @@
         }
     ],
     "wof:id":1108757589,
-    "wof:lastmodified":1636495671,
+    "wof:lastmodified":1695886660,
     "wof:name":"Nabeul",
     "wof:parent_id":85679119,
     "wof:placetype":"county",

--- a/data/110/875/759/1/1108757591.geojson
+++ b/data/110/875/759/1/1108757591.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014669,
-    "geom:area_square_m":145394364.38666,
+    "geom:area_square_m":145394612.358059,
     "geom:bbox":"10.406425,36.629599,10.612356,36.849583",
     "geom:latitude":36.719428,
     "geom:longitude":10.523893,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.NB.SO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307292,
-    "wof:geomhash":"9ce87af10eaf8a1e3f4418da5ff245b6",
+    "wof:geomhash":"a093a6b07ab9233d5038419963779da0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757591,
-    "wof:lastmodified":1627522834,
+    "wof:lastmodified":1695886548,
     "wof:name":"Sliman",
     "wof:parent_id":85679119,
     "wof:placetype":"county",

--- a/data/110/875/759/3/1108757593.geojson
+++ b/data/110/875/759/3/1108757593.geojson
@@ -78,9 +78,10 @@
     "wof:concordances":{
         "hasc:id":"TN.NB.TA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307293,
-    "wof:geomhash":"b0a9572f49e3c533d34f49ccfb153d2f",
+    "wof:geomhash":"a4cc3572a654eb3ca45ff972ee0989e9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1108757593,
-    "wof:lastmodified":1566667265,
+    "wof:lastmodified":1695886582,
     "wof:name":"Takelsa",
     "wof:parent_id":85679119,
     "wof:placetype":"county",

--- a/data/110/875/759/5/1108757595.geojson
+++ b/data/110/875/759/5/1108757595.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.071938,
-    "geom:area_square_m":730974410.103029,
+    "geom:area_square_m":730974410.103038,
     "geom:bbox":"10.269164699,34.5896494202,10.6554745164,34.8854305222",
     "geom:latitude":34.739481,
     "geom:longitude":10.451601,
@@ -84,9 +84,10 @@
     "wof:concordances":{
         "hasc:id":"TN.SF.AG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307294,
-    "wof:geomhash":"75aa695bf4547d0c065c2770e6252e0c",
+    "wof:geomhash":"814f68142d0916eb3e8ec47f15d8542d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":1108757595,
-    "wof:lastmodified":1566667265,
+    "wof:lastmodified":1695886583,
     "wof:name":"Agareb",
     "wof:parent_id":85679151,
     "wof:placetype":"county",

--- a/data/110/875/759/7/1108757597.geojson
+++ b/data/110/875/759/7/1108757597.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.119162,
-    "geom:area_square_m":1211125239.266375,
+    "geom:area_square_m":1211125292.419711,
     "geom:bbox":"9.868154,34.519675,10.337329,34.996776",
     "geom:latitude":34.718604,
     "geom:longitude":10.094572,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.SF.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307296,
-    "wof:geomhash":"0aeedce1af7be20ae91c2deb7433b0fb",
+    "wof:geomhash":"dc1982c35d5b73d38fc063b42473fd0f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757597,
-    "wof:lastmodified":1627522824,
+    "wof:lastmodified":1695886531,
     "wof:name":"Bir Ali Ben Kh\u00e0lifa",
     "wof:parent_id":85679151,
     "wof:placetype":"county",

--- a/data/110/875/759/9/1108757599.geojson
+++ b/data/110/875/759/9/1108757599.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.025504,
-    "geom:area_square_m":258089415.384329,
+    "geom:area_square_m":258089346.845758,
     "geom:bbox":"10.786076,34.993247,11.027861,35.172856",
     "geom:latitude":35.075243,
     "geom:longitude":10.902501,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.SF.DJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307297,
-    "wof:geomhash":"da4b8c7c2a7304065c47d17767b35df0",
+    "wof:geomhash":"e3f0fd7691409927e8ffcaca7b2d10ca",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757599,
-    "wof:lastmodified":1627522829,
+    "wof:lastmodified":1695886539,
     "wof:name":"Djebeniana",
     "wof:parent_id":85679151,
     "wof:placetype":"county",

--- a/data/110/875/760/3/1108757603.geojson
+++ b/data/110/875/760/3/1108757603.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.050237,
-    "geom:area_square_m":508228879.517424,
+    "geom:area_square_m":508228965.891735,
     "geom:bbox":"10.594254,34.885846,10.836077,35.266486",
     "geom:latitude":35.099157,
     "geom:longitude":10.727624,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.SF.HA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307298,
-    "wof:geomhash":"8aa413eedcda78c4876c52f7de288af0",
+    "wof:geomhash":"87636485204757461ab2e7c7f317edbf",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757603,
-    "wof:lastmodified":1627522826,
+    "wof:lastmodified":1695886534,
     "wof:name":"El Hancha",
     "wof:parent_id":85679151,
     "wof:placetype":"county",

--- a/data/110/875/760/5/1108757605.geojson
+++ b/data/110/875/760/5/1108757605.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018464,
-    "geom:area_square_m":187154596.59385,
+    "geom:area_square_m":187154590.421022,
     "geom:bbox":"10.795867,34.842928,10.962094,35.023665",
     "geom:latitude":34.943095,
     "geom:longitude":10.870641,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.SF.AM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307299,
-    "wof:geomhash":"7cf1ca92ce5ecc513d32e0b51a74b90d",
+    "wof:geomhash":"e8b212ce79badc7fba7a3985b4216fd8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757605,
-    "wof:lastmodified":1627522826,
+    "wof:lastmodified":1695886534,
     "wof:name":"El-Amra",
     "wof:parent_id":85679151,
     "wof:placetype":"county",

--- a/data/110/875/760/7/1108757607.geojson
+++ b/data/110/875/760/7/1108757607.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.042968,
-    "geom:area_square_m":437874285.88751,
+    "geom:area_square_m":437874420.818415,
     "geom:bbox":"10.053258,34.348751,10.35924,34.623518",
     "geom:latitude":34.498485,
     "geom:longitude":10.215821,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.SF.GH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307300,
-    "wof:geomhash":"34398f4e295a8d678649a94f662ef8e1",
+    "wof:geomhash":"f0d7ae26492d90430bfc37f205888544",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757607,
-    "wof:lastmodified":1627522828,
+    "wof:lastmodified":1695886537,
     "wof:name":"Ghraiba",
     "wof:parent_id":85679151,
     "wof:placetype":"county",

--- a/data/110/875/760/9/1108757609.geojson
+++ b/data/110/875/760/9/1108757609.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.159594,
-    "geom:area_square_m":1616647968.485111,
+    "geom:area_square_m":1616647637.49732,
     "geom:bbox":"10.055418,34.814494,10.709157,35.222149",
     "geom:latitude":34.993421,
     "geom:longitude":10.376737,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.SF.MC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307302,
-    "wof:geomhash":"b2ed7e8a812a4d3c26106845ecc49f35",
+    "wof:geomhash":"19d74eed6923420f27de0b524fc251bf",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757609,
-    "wof:lastmodified":1627522831,
+    "wof:lastmodified":1695886543,
     "wof:name":"Menzil Chaker",
     "wof:parent_id":85679151,
     "wof:placetype":"county",

--- a/data/110/875/761/1/1108757611.geojson
+++ b/data/110/875/761/1/1108757611.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.042416,
-    "geom:area_square_m":432017569.258379,
+    "geom:area_square_m":432017569.258392,
     "geom:bbox":"10.2736210125,34.392860413,10.6170399128,34.6577347703",
     "geom:latitude":34.542008,
     "geom:longitude":10.435113,
@@ -84,9 +84,10 @@
     "wof:concordances":{
         "hasc:id":"TN.SF.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307303,
-    "wof:geomhash":"560373387374d42ba30c65c52e46e30d",
+    "wof:geomhash":"9dc472bd618849fdec9b2efba4586c29",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":1108757611,
-    "wof:lastmodified":1566667263,
+    "wof:lastmodified":1695886582,
     "wof:name":"Mahres",
     "wof:parent_id":85679151,
     "wof:placetype":"county",

--- a/data/110/875/761/3/1108757613.geojson
+++ b/data/110/875/761/3/1108757613.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011088,
-    "geom:area_square_m":112538073.343128,
+    "geom:area_square_m":112537940.927005,
     "geom:bbox":"10.76485,34.750948,10.887519,34.907619",
     "geom:latitude":34.830349,
     "geom:longitude":10.815311,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.SF.SD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307304,
-    "wof:geomhash":"3f97004b19c9e666bf75faa11030c57f",
+    "wof:geomhash":"d897ab93956404a93163b104f0065396",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757613,
-    "wof:lastmodified":1627522833,
+    "wof:lastmodified":1695886546,
     "wof:name":"Sakiet Eddaier",
     "wof:parent_id":85679151,
     "wof:placetype":"county",

--- a/data/110/875/761/5/1108757615.geojson
+++ b/data/110/875/761/5/1108757615.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008776,
-    "geom:area_square_m":89049173.347985,
+    "geom:area_square_m":89049173.34799,
     "geom:bbox":"10.6825196204,34.7687157216,10.7791815773,34.9451381683",
     "geom:latitude":34.858012,
     "geom:longitude":10.739526,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"TN.SF.SZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307305,
-    "wof:geomhash":"3ef59f1885b08fbda07be8c982f78f32",
+    "wof:geomhash":"647128b2179d496295744d3fc55c57cf",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1108757615,
-    "wof:lastmodified":1566667264,
+    "wof:lastmodified":1695886582,
     "wof:name":"Sakiet Ezzit",
     "wof:parent_id":85679151,
     "wof:placetype":"county",

--- a/data/110/875/761/7/1108757617.geojson
+++ b/data/110/875/761/7/1108757617.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015669,
-    "geom:area_square_m":159282670.227696,
+    "geom:area_square_m":159282605.584304,
     "geom:bbox":"10.297889,34.355389,11.322861,34.831249",
     "geom:latitude":34.703903,
     "geom:longitude":11.147008,
@@ -216,7 +216,7 @@
     "wof:concordances":{},
     "wof:country":"TN",
     "wof:created":1481307306,
-    "wof:geomhash":"38f169cf459195eecf1eb83278d24842",
+    "wof:geomhash":"b2635cfb53425a94fde556f8ea33d57e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -226,7 +226,7 @@
         }
     ],
     "wof:id":1108757617,
-    "wof:lastmodified":1636495671,
+    "wof:lastmodified":1695886660,
     "wof:name":"Sfax",
     "wof:parent_id":85679151,
     "wof:placetype":"county",

--- a/data/110/875/762/1/1108757621.geojson
+++ b/data/110/875/762/1/1108757621.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002522,
-    "geom:area_square_m":25629646.937484,
+    "geom:area_square_m":25629693.973423,
     "geom:bbox":"10.721639,34.683745,10.785517,34.768971",
     "geom:latitude":34.735485,
     "geom:longitude":10.752488,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.SF.SM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307308,
-    "wof:geomhash":"735bec00f398660afba9ad8aab8e339e",
+    "wof:geomhash":"16be00b0f4cb1a26a72a58909cf24d3b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757621,
-    "wof:lastmodified":1627522833,
+    "wof:lastmodified":1695886546,
     "wof:name":"Sfax Madine",
     "wof:parent_id":85679151,
     "wof:placetype":"county",

--- a/data/110/875/762/3/1108757623.geojson
+++ b/data/110/875/762/3/1108757623.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001497,
-    "geom:area_square_m":15211894.122913,
+    "geom:area_square_m":15211809.067163,
     "geom:bbox":"10.691297,34.705161,10.742048,34.75707",
     "geom:latitude":34.732638,
     "geom:longitude":10.719815,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.SF.SO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307309,
-    "wof:geomhash":"e56aeeaf9969fcc3f0b378b4df8fcc71",
+    "wof:geomhash":"1f77858cf9fab61102f8072b4431d869",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757623,
-    "wof:lastmodified":1627522833,
+    "wof:lastmodified":1695886547,
     "wof:name":"Sfax Ouest",
     "wof:parent_id":85679151,
     "wof:placetype":"county",

--- a/data/110/875/762/5/1108757625.geojson
+++ b/data/110/875/762/5/1108757625.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.021736,
-    "geom:area_square_m":220633317.140239,
+    "geom:area_square_m":220633228.462526,
     "geom:bbox":"10.579926,34.726367,10.746133,34.94655",
     "geom:latitude":34.826845,
     "geom:longitude":10.661977,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.SF.SS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307310,
-    "wof:geomhash":"93d259e28235dcb7d6cebeef78ed96d2",
+    "wof:geomhash":"1ce2e410224c345476f541f04b93b0e9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757625,
-    "wof:lastmodified":1627522833,
+    "wof:lastmodified":1695886547,
     "wof:name":"Sfax Sud",
     "wof:parent_id":85679151,
     "wof:placetype":"county",

--- a/data/110/875/762/7/1108757627.geojson
+++ b/data/110/875/762/7/1108757627.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.089601,
-    "geom:area_square_m":914957508.818889,
+    "geom:area_square_m":914957508.81884,
     "geom:bbox":"9.69918410833,34.1655144472,10.1922185583,34.520416483",
     "geom:latitude":34.327965,
     "geom:longitude":9.963696,
@@ -93,9 +93,10 @@
     "wof:concordances":{
         "hasc:id":"TN.SF.SK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307311,
-    "wof:geomhash":"3357fef4198e7e8503df507fee67d46c",
+    "wof:geomhash":"888bf14d368c78b3d486dddea5cac146",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108757627,
-    "wof:lastmodified":1566667243,
+    "wof:lastmodified":1695886579,
     "wof:name":"Skhira",
     "wof:parent_id":85679151,
     "wof:placetype":"county",

--- a/data/110/875/762/9/1108757629.geojson
+++ b/data/110/875/762/9/1108757629.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.0092,
-    "geom:area_square_m":93540292.346667,
+    "geom:area_square_m":93540292.346666,
     "geom:bbox":"10.6049742784,34.634555817,10.753749847,34.731226811",
     "geom:latitude":34.684182,
     "geom:longitude":10.676946,
@@ -117,9 +117,10 @@
     "wof:concordances":{
         "hasc:id":"TN.SF.TH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307312,
-    "wof:geomhash":"f3734ed786f54a9c573f29646a80b284",
+    "wof:geomhash":"3f34846645120caf58cba5ce51a79491",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":1108757629,
-    "wof:lastmodified":1566667243,
+    "wof:lastmodified":1695886579,
     "wof:name":"Tina",
     "wof:parent_id":85679151,
     "wof:placetype":"county",

--- a/data/110/875/763/1/1108757631.geojson
+++ b/data/110/875/763/1/1108757631.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.05019,
-    "geom:area_square_m":509034761.990984,
+    "geom:area_square_m":509034761.990993,
     "geom:bbox":"9.10077799573,34.7185495002,9.41800901589,35.0180891032",
     "geom:latitude":34.892845,
     "geom:longitude":9.278239,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"TN.SZ.BH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307313,
-    "wof:geomhash":"dd64d4e1bf999b941f5686e3104e20c2",
+    "wof:geomhash":"2706c5c53e5104074c6202a9674bdeb8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1108757631,
-    "wof:lastmodified":1566667235,
+    "wof:lastmodified":1695886577,
     "wof:name":"Bir El Hafey",
     "wof:parent_id":85679147,
     "wof:placetype":"county",

--- a/data/110/875/763/3/1108757633.geojson
+++ b/data/110/875/763/3/1108757633.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.064038,
-    "geom:area_square_m":645977990.228367,
+    "geom:area_square_m":645978365.623914,
     "geom:bbox":"9.211058,35.161029,9.560315,35.482304",
     "geom:latitude":35.334125,
     "geom:longitude":9.395758,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.SZ.JI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307314,
-    "wof:geomhash":"e63af4d1dfaa2cf7405e66a3536529c2",
+    "wof:geomhash":"864c85587888eeb740928c9a51ac643f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757633,
-    "wof:lastmodified":1627522829,
+    "wof:lastmodified":1695886539,
     "wof:name":"Jelma",
     "wof:parent_id":85679147,
     "wof:placetype":"county",

--- a/data/110/875/763/5/1108757635.geojson
+++ b/data/110/875/763/5/1108757635.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.111019,
-    "geom:area_square_m":1131951839.730296,
+    "geom:area_square_m":1131951745.152963,
     "geom:bbox":"9.460106,34.266153,10.049679,34.652923",
     "geom:latitude":34.454692,
     "geom:longitude":9.744473,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.SZ.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307315,
-    "wof:geomhash":"6db928c940ebc810474042db97e015fd",
+    "wof:geomhash":"68941b81786e1510b69ed26b1a10115e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757635,
-    "wof:lastmodified":1627522831,
+    "wof:lastmodified":1695886543,
     "wof:name":"Mazzouna",
     "wof:parent_id":85679147,
     "wof:placetype":"county",

--- a/data/110/875/763/9/1108757639.geojson
+++ b/data/110/875/763/9/1108757639.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.060111,
-    "geom:area_square_m":611638744.800622,
+    "geom:area_square_m":611638682.894994,
     "geom:bbox":"9.441954,34.479461,9.819409,34.782577",
     "geom:latitude":34.625699,
     "geom:longitude":9.617102,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.SZ.ME"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307322,
-    "wof:geomhash":"3bd1a6349090db9eb13a8e497142a3b2",
+    "wof:geomhash":"1508e6a8801816b543c03a72b30e130f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757639,
-    "wof:lastmodified":1627522831,
+    "wof:lastmodified":1695886543,
     "wof:name":"Meknassi",
     "wof:parent_id":85679147,
     "wof:placetype":"county",

--- a/data/110/875/764/1/1108757641.geojson
+++ b/data/110/875/764/1/1108757641.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.05808,
-    "geom:area_square_m":590949549.963524,
+    "geom:area_square_m":590949620.820712,
     "geom:bbox":"9.259833,34.477962,9.552814,34.773008",
     "geom:latitude":34.628981,
     "geom:longitude":9.402311,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.SZ.MB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307323,
-    "wof:geomhash":"96057d8c20b89a481c69b520102efae1",
+    "wof:geomhash":"fe6d9075986bb28b2ead0e2aa5f66db2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757641,
-    "wof:lastmodified":1627522831,
+    "wof:lastmodified":1695886543,
     "wof:name":"Menzil Bouzayanne",
     "wof:parent_id":85679147,
     "wof:placetype":"county",

--- a/data/110/875/764/3/1108757643.geojson
+++ b/data/110/875/764/3/1108757643.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.039029,
-    "geom:area_square_m":394827676.836515,
+    "geom:area_square_m":394828013.745162,
     "geom:bbox":"9.700812,34.989618,9.9951,35.192686",
     "geom:latitude":35.102313,
     "geom:longitude":9.844795,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.SZ.OH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307324,
-    "wof:geomhash":"527867bfdfb658125253c152c6cae1c4",
+    "wof:geomhash":"28414458bbdf836716f6f5762af8eb65",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757643,
-    "wof:lastmodified":1627522832,
+    "wof:lastmodified":1695886545,
     "wof:name":"oueled Haffouz",
     "wof:parent_id":85679147,
     "wof:placetype":"county",

--- a/data/110/875/764/5/1108757645.geojson
+++ b/data/110/875/764/5/1108757645.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.102728,
-    "geom:area_square_m":1042261723.547541,
+    "geom:area_square_m":1042261723.547551,
     "geom:bbox":"9.62837493338,34.6441142583,10.0648240733,35.0645443545",
     "geom:latitude":34.863418,
     "geom:longitude":9.839702,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"TN.SZ.RE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307326,
-    "wof:geomhash":"008f850ff7673ca2f29fac4fbb17d7b6",
+    "wof:geomhash":"1ea2278e12cf4f2d1602cef4bd189735",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1108757645,
-    "wof:lastmodified":1566667236,
+    "wof:lastmodified":1695886577,
     "wof:name":"Regueb",
     "wof:parent_id":85679147,
     "wof:placetype":"county",

--- a/data/110/875/764/7/1108757647.geojson
+++ b/data/110/875/764/7/1108757647.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.030554,
-    "geom:area_square_m":308608558.28589,
+    "geom:area_square_m":308608380.388907,
     "geom:bbox":"9.158025,35.081102,9.379715,35.391346",
     "geom:latitude":35.229189,
     "geom:longitude":9.273982,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.SZ.SA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307327,
-    "wof:geomhash":"340e2510bdcb97e36cc501b3fe2ddce4",
+    "wof:geomhash":"26fd4290724c51e236c2d1a43933963f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757647,
-    "wof:lastmodified":1627522825,
+    "wof:lastmodified":1695886532,
     "wof:name":"Sabalet Ouled Askar",
     "wof:parent_id":85679147,
     "wof:placetype":"county",

--- a/data/110/875/764/9/1108757649.geojson
+++ b/data/110/875/764/9/1108757649.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.060009,
-    "geom:area_square_m":609378040.400865,
+    "geom:area_square_m":609378040.400866,
     "geom:bbox":"8.92132229549,34.6785489025,9.31382233724,34.9443099443",
     "geom:latitude":34.791624,
     "geom:longitude":9.117936,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"TN.SZ.SB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307329,
-    "wof:geomhash":"e6ff0a5f246bc759f52efe7a242d3238",
+    "wof:geomhash":"1dcdf353c56fef262c31a49de202ce74",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1108757649,
-    "wof:lastmodified":1566667235,
+    "wof:lastmodified":1695886577,
     "wof:name":"Sidi Ali Ben Aoun",
     "wof:parent_id":85679147,
     "wof:placetype":"county",

--- a/data/110/875/765/1/1108757651.geojson
+++ b/data/110/875/765/1/1108757651.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.077295,
-    "geom:area_square_m":782128350.954277,
+    "geom:area_square_m":782128360.875598,
     "geom:bbox":"9.419747,34.862633,9.792301,35.274868",
     "geom:latitude":35.082826,
     "geom:longitude":9.596276,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.SZ.SE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307330,
-    "wof:geomhash":"39edac6c956ab90ac4f5caf5765b16ce",
+    "wof:geomhash":"b530000334799f157153e0d1171db6b9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757651,
-    "wof:lastmodified":1627522833,
+    "wof:lastmodified":1695886547,
     "wof:name":"Sidi Bou Zid Est",
     "wof:parent_id":85679147,
     "wof:placetype":"county",

--- a/data/110/875/765/3/1108757653.geojson
+++ b/data/110/875/765/3/1108757653.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.042147,
-    "geom:area_square_m":426866096.330897,
+    "geom:area_square_m":426866149.613357,
     "geom:bbox":"9.275396,34.787648,9.526209,35.176381",
     "geom:latitude":35.008379,
     "geom:longitude":9.409403,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.SZ.SO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307331,
-    "wof:geomhash":"92e7a14800e2832afe989a3917c08dc3",
+    "wof:geomhash":"835b61f8ee73442c21949962aa8c6638",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757653,
-    "wof:lastmodified":1627522833,
+    "wof:lastmodified":1695886547,
     "wof:name":"Sidi bouzid Ouest",
     "wof:parent_id":85679147,
     "wof:placetype":"county",

--- a/data/110/875/765/7/1108757657.geojson
+++ b/data/110/875/765/7/1108757657.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.034688,
-    "geom:area_square_m":351961447.55302,
+    "geom:area_square_m":351961492.867931,
     "geom:bbox":"9.405933,34.743757,9.703913,34.978521",
     "geom:latitude":34.85709,
     "geom:longitude":9.561902,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.SZ.SJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307332,
-    "wof:geomhash":"10f2591a4ee3e864555d74108dd34388",
+    "wof:geomhash":"c443b59d924c2d877decdf69b80d9809",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757657,
-    "wof:lastmodified":1627522834,
+    "wof:lastmodified":1695886548,
     "wof:name":"Souk Jedid",
     "wof:parent_id":85679147,
     "wof:placetype":"county",

--- a/data/110/875/765/9/1108757659.geojson
+++ b/data/110/875/765/9/1108757659.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.045152,
-    "geom:area_square_m":451122571.449666,
+    "geom:area_square_m":451122571.449661,
     "geom:bbox":"9.48089595814,35.9649524187,9.76389553724,36.2193178938",
     "geom:latitude":36.097381,
     "geom:longitude":9.613988,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"TN.SL.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307333,
-    "wof:geomhash":"9f0b95b6b78a3ccdd0e596bd5e5d2cd3",
+    "wof:geomhash":"5971cfa4d5bd6344c79660fa9e68dafa",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1108757659,
-    "wof:lastmodified":1566667242,
+    "wof:lastmodified":1695886578,
     "wof:name":"Bargou",
     "wof:parent_id":85679157,
     "wof:placetype":"county",

--- a/data/110/875/766/1/1108757661.geojson
+++ b/data/110/875/766/1/1108757661.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.040679,
-    "geom:area_square_m":405283037.044948,
+    "geom:area_square_m":405282928.062505,
     "geom:bbox":"9.4793,36.173658,9.75622,36.453259",
     "geom:latitude":36.31943,
     "geom:longitude":9.620591,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.SL.BD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307334,
-    "wof:geomhash":"72d81c14bbb6169cef02662c8df645d8",
+    "wof:geomhash":"3be2a44ea46d351c4d38e451c04dd63c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757661,
-    "wof:lastmodified":1627522825,
+    "wof:lastmodified":1695886532,
     "wof:name":"Bouarada",
     "wof:parent_id":85679157,
     "wof:placetype":"county",

--- a/data/110/875/766/3/1108757663.geojson
+++ b/data/110/875/766/3/1108757663.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.02746,
-    "geom:area_square_m":274071425.740879,
+    "geom:area_square_m":274071280.181415,
     "geom:bbox":"9.034212,36.085318,9.244506,36.281839",
     "geom:latitude":36.180998,
     "geom:longitude":9.13454,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.SL.BR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307335,
-    "wof:geomhash":"1d77786299592bb746429f0a05cb4977",
+    "wof:geomhash":"a755b4c1831964831e98b82d6099528f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757663,
-    "wof:lastmodified":1627522833,
+    "wof:lastmodified":1695886547,
     "wof:name":"Bourouis",
     "wof:parent_id":85679157,
     "wof:placetype":"county",

--- a/data/110/875/766/5/1108757665.geojson
+++ b/data/110/875/766/5/1108757665.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.034146,
-    "geom:area_square_m":340003780.200615,
+    "geom:area_square_m":340003780.200602,
     "geom:bbox":"9.31871027834,36.2400050389,9.57038221326,36.4565416153",
     "geom:latitude":36.363299,
     "geom:longitude":9.457473,
@@ -75,9 +75,10 @@
     "wof:concordances":{
         "hasc:id":"TN.SL.LA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307336,
-    "wof:geomhash":"65bc3621b67f5e74d71690be31a33277",
+    "wof:geomhash":"e0c9c7257d0311ac286340c3eba80fa9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -87,7 +88,7 @@
         }
     ],
     "wof:id":1108757665,
-    "wof:lastmodified":1566667265,
+    "wof:lastmodified":1695886583,
     "wof:name":"El Aroussa",
     "wof:parent_id":85679157,
     "wof:placetype":"county",

--- a/data/110/875/766/7/1108757667.geojson
+++ b/data/110/875/766/7/1108757667.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.047675,
-    "geom:area_square_m":475520281.706633,
+    "geom:area_square_m":475520282.244704,
     "geom:bbox":"9.178295,36.127261,9.522057,36.371106",
     "geom:latitude":36.230809,
     "geom:longitude":9.341312,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.SL.GA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307337,
-    "wof:geomhash":"6b73f0dea6a8719a2d3d40e5246e40c6",
+    "wof:geomhash":"fff9d10258ec28577c77fa2481b9dd91",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757667,
-    "wof:lastmodified":1627522827,
+    "wof:lastmodified":1695886535,
     "wof:name":"G\u00e0afour",
     "wof:parent_id":85679157,
     "wof:placetype":"county",

--- a/data/110/875/766/9/1108757669.geojson
+++ b/data/110/875/766/9/1108757669.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.042975,
-    "geom:area_square_m":431056869.771997,
+    "geom:area_square_m":431056869.771998,
     "geom:bbox":"9.1940031139,35.6879675653,9.53888393395,35.9067845961",
     "geom:latitude":35.789373,
     "geom:longitude":9.382966,
@@ -75,9 +75,10 @@
     "wof:concordances":{
         "hasc:id":"TN.SL.KI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307338,
-    "wof:geomhash":"39969d2969624adbd92463c4bcc46528",
+    "wof:geomhash":"2ec28b2b6ba19f890823eb526586c07a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -87,7 +88,7 @@
         }
     ],
     "wof:id":1108757669,
-    "wof:lastmodified":1566667264,
+    "wof:lastmodified":1695886582,
     "wof:name":"Kesra",
     "wof:parent_id":85679157,
     "wof:placetype":"county",

--- a/data/110/875/767/1/1108757671.geojson
+++ b/data/110/875/767/1/1108757671.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.042459,
-    "geom:area_square_m":422895416.947397,
+    "geom:area_square_m":422895428.68034,
     "geom:bbox":"8.928141,36.233612,9.270837,36.458594",
     "geom:latitude":36.341292,
     "geom:longitude":9.0789,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.SL.EL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307339,
-    "wof:geomhash":"69aa70fd6a32440c9da27011e3e5a224",
+    "wof:geomhash":"7af1a494359a7972dfc725a9d974b4ce",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757671,
-    "wof:lastmodified":1627522827,
+    "wof:lastmodified":1695886535,
     "wof:name":"Krib",
     "wof:parent_id":85679157,
     "wof:placetype":"county",

--- a/data/110/875/767/5/1108757675.geojson
+++ b/data/110/875/767/5/1108757675.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.034844,
-    "geom:area_square_m":349203742.800841,
+    "geom:area_square_m":349203882.26609,
     "geom:bbox":"9.031141,35.750155,9.29826,35.980297",
     "geom:latitude":35.856613,
     "geom:longitude":9.160286,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.SL.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307340,
-    "wof:geomhash":"8deccfb3eb4e0333e089371d08a3b83a",
+    "wof:geomhash":"f12187c0cc2465b2bde03850af38a41a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757675,
-    "wof:lastmodified":1627522831,
+    "wof:lastmodified":1695886544,
     "wof:name":"Makthar",
     "wof:parent_id":85679157,
     "wof:placetype":"county",

--- a/data/110/875/767/7/1108757677.geojson
+++ b/data/110/875/767/7/1108757677.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.063499,
-    "geom:area_square_m":638081367.999671,
+    "geom:area_square_m":638081367.999672,
     "geom:bbox":"8.9673552963,35.472812719,9.42918543805,35.8101740039",
     "geom:latitude":35.643629,
     "geom:longitude":9.203647,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"TN.SL.RO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307341,
-    "wof:geomhash":"6ae0fddf51ef9b3b3ee49eb7611c4726",
+    "wof:geomhash":"7b7b66d9b86293993f9cdfea8f1c3300",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1108757677,
-    "wof:lastmodified":1566667256,
+    "wof:lastmodified":1695886581,
     "wof:name":"Rouhia",
     "wof:parent_id":85679157,
     "wof:placetype":"county",

--- a/data/110/875/767/9/1108757679.geojson
+++ b/data/110/875/767/9/1108757679.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.03707,
-    "geom:area_square_m":370568855.20508,
+    "geom:area_square_m":370568888.847147,
     "geom:bbox":"9.135718,35.903941,9.496171,36.156142",
     "geom:latitude":36.057233,
     "geom:longitude":9.282259,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.SL.SN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307343,
-    "wof:geomhash":"e38a5a438aa53371ad65bf1546c2c2be",
+    "wof:geomhash":"c8770bc0b1f7fcdc923588636d253782",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757679,
-    "wof:lastmodified":1627522834,
+    "wof:lastmodified":1695886549,
     "wof:name":"Siliana Nord",
     "wof:parent_id":85679157,
     "wof:placetype":"county",

--- a/data/110/875/768/1/1108757681.geojson
+++ b/data/110/875/768/1/1108757681.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.049304,
-    "geom:area_square_m":493394666.423466,
+    "geom:area_square_m":493394529.001623,
     "geom:bbox":"9.245231,35.849518,9.592927,36.099612",
     "geom:latitude":35.971291,
     "geom:longitude":9.401869,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.SL.SS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307344,
-    "wof:geomhash":"3a43729a922229ae1d1147ab9f72ae34",
+    "wof:geomhash":"7fbe61b3242406ec78680e369706b081",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757681,
-    "wof:lastmodified":1627522834,
+    "wof:lastmodified":1695886549,
     "wof:name":"siliana Sud",
     "wof:parent_id":85679157,
     "wof:placetype":"county",

--- a/data/110/875/768/3/1108757683.geojson
+++ b/data/110/875/768/3/1108757683.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005016,
-    "geom:area_square_m":50233142.375205,
+    "geom:area_square_m":50233142.3752,
     "geom:bbox":"10.5016660173,35.8432569427,10.5918154087,35.9747774809",
     "geom:latitude":35.91373,
     "geom:longitude":10.549529,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"TN.SS.AK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307345,
-    "wof:geomhash":"4eebc346bd679491a3ccae928ec16563",
+    "wof:geomhash":"ec9e3b47a90f4e96013d0c9bdf0a0047",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1108757683,
-    "wof:lastmodified":1566667263,
+    "wof:lastmodified":1695886582,
     "wof:name":"Akouda",
     "wof:parent_id":85679173,
     "wof:placetype":"county",

--- a/data/110/875/768/5/1108757685.geojson
+++ b/data/110/875/768/5/1108757685.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.025366,
-    "geom:area_square_m":252857352.81964,
+    "geom:area_square_m":252857352.819644,
     "geom:bbox":"10.3278040611,36.1710449928,10.5315906662,36.378586303",
     "geom:latitude":36.27622,
     "geom:longitude":10.429532,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"TN.SS.BO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307347,
-    "wof:geomhash":"fb93478b2077ce9f613fd1a5ee0e829c",
+    "wof:geomhash":"31e92b1868d23b74f3a02b5556eee40e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1108757685,
-    "wof:lastmodified":1566667263,
+    "wof:lastmodified":1695886582,
     "wof:name":"Bouficha",
     "wof:parent_id":85679173,
     "wof:placetype":"county",

--- a/data/110/875/768/7/1108757687.geojson
+++ b/data/110/875/768/7/1108757687.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.038543,
-    "geom:area_square_m":385023472.571883,
+    "geom:area_square_m":385023472.571872,
     "geom:bbox":"10.1888259087,36.0162512006,10.4771001188,36.222925105",
     "geom:latitude":36.112578,
     "geom:longitude":10.326793,
@@ -102,9 +102,10 @@
     "wof:concordances":{
         "hasc:id":"TN.SS.EN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307348,
-    "wof:geomhash":"8e50b1b16eced2e2956b411d02878124",
+    "wof:geomhash":"2eece1305380f36f308b5dc26ab69e6b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1108757687,
-    "wof:lastmodified":1566667263,
+    "wof:lastmodified":1695886582,
     "wof:name":"Enfidha",
     "wof:parent_id":85679173,
     "wof:placetype":"county",

--- a/data/110/875/768/9/1108757689.geojson
+++ b/data/110/875/768/9/1108757689.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001892,
-    "geom:area_square_m":18960910.039717,
+    "geom:area_square_m":18960910.039716,
     "geom:bbox":"10.5672359456,35.8307088761,10.6212140842,35.9027244366",
     "geom:latitude":35.863533,
     "geom:longitude":10.592589,
@@ -108,9 +108,10 @@
     "wof:concordances":{
         "hasc:id":"TN.SS.HS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307349,
-    "wof:geomhash":"8f49b070150b67469c8e3903589af6f9",
+    "wof:geomhash":"420f1e15ce7f01ffa6baf8e5be706761",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -120,7 +121,7 @@
         }
     ],
     "wof:id":1108757689,
-    "wof:lastmodified":1566667263,
+    "wof:lastmodified":1695886582,
     "wof:name":"Hammam Sousse",
     "wof:parent_id":85679173,
     "wof:placetype":"county",

--- a/data/110/875/769/3/1108757693.geojson
+++ b/data/110/875/769/3/1108757693.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010603,
-    "geom:area_square_m":106030113.166246,
+    "geom:area_square_m":106030118.942393,
     "geom:bbox":"10.363226,35.962443,10.535535,36.085652",
     "geom:latitude":36.025026,
     "geom:longitude":10.455843,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.SS.HE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307351,
-    "wof:geomhash":"66653583fd2ae6b0f48ff5fbc4ce264d",
+    "wof:geomhash":"171fa04e9f3cedd31c30e147f28e7f20",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757693,
-    "wof:lastmodified":1627522829,
+    "wof:lastmodified":1695886539,
     "wof:name":"Hergela",
     "wof:parent_id":85679173,
     "wof:placetype":"county",

--- a/data/110/875/769/5/1108757695.geojson
+++ b/data/110/875/769/5/1108757695.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.030994,
-    "geom:area_square_m":310590847.449241,
+    "geom:area_square_m":310590915.177726,
     "geom:bbox":"10.221915,35.785097,10.553152,35.956028",
     "geom:latitude":35.863725,
     "geom:longitude":10.402423,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.SS.KK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307352,
-    "wof:geomhash":"856c0f2500820b74feaa56bd8913398d",
+    "wof:geomhash":"5ff64e8c052cd8e2f6726aeccbd0c7f3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757695,
-    "wof:lastmodified":1627522829,
+    "wof:lastmodified":1695886539,
     "wof:name":"Kal\u00e0a Kebira",
     "wof:parent_id":85679173,
     "wof:placetype":"county",

--- a/data/110/875/769/7/1108757697.geojson
+++ b/data/110/875/769/7/1108757697.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010088,
-    "geom:area_square_m":101175657.028787,
+    "geom:area_square_m":101175570.16555,
     "geom:bbox":"10.368511,35.745973,10.594703,35.845781",
     "geom:latitude":35.797818,
     "geom:longitude":10.481049,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.SS.KS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307353,
-    "wof:geomhash":"4ea245f00d623bc3facefaf341a57513",
+    "wof:geomhash":"3f607c1b76855adcbc51bf71987bdf7c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757697,
-    "wof:lastmodified":1627522829,
+    "wof:lastmodified":1695886539,
     "wof:name":"Kal\u00e0a Sghira",
     "wof:parent_id":85679173,
     "wof:placetype":"county",

--- a/data/110/875/769/9/1108757699.geojson
+++ b/data/110/875/769/9/1108757699.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022047,
-    "geom:area_square_m":220806314.987457,
+    "geom:area_square_m":220806346.839279,
     "geom:bbox":"10.1562,35.769725,10.359528,36.028927",
     "geom:latitude":35.907761,
     "geom:longitude":10.259182,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.SS.KO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307354,
-    "wof:geomhash":"db560a056e6c9f75c39f009dca6e5c0f",
+    "wof:geomhash":"6895012fe45ba7e25ccd73298d06f1f0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757699,
-    "wof:lastmodified":1627522830,
+    "wof:lastmodified":1695886541,
     "wof:name":"Kendar",
     "wof:parent_id":85679173,
     "wof:placetype":"county",

--- a/data/110/875/770/1/1108757701.geojson
+++ b/data/110/875/770/1/1108757701.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.034171,
-    "geom:area_square_m":343234493.509659,
+    "geom:area_square_m":343234696.582496,
     "geom:bbox":"10.427721,35.51789,10.64393,35.789107",
     "geom:latitude":35.676544,
     "geom:longitude":10.538559,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.SS.MS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307355,
-    "wof:geomhash":"040987b05c53d92d73a3ae3998c86354",
+    "wof:geomhash":"4680fff9f3662100bccac143c4401326",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757701,
-    "wof:lastmodified":1627522830,
+    "wof:lastmodified":1695886541,
     "wof:name":"Messaken",
     "wof:parent_id":85679173,
     "wof:placetype":"county",

--- a/data/110/875/770/3/1108757703.geojson
+++ b/data/110/875/770/3/1108757703.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011588,
-    "geom:area_square_m":115970716.091469,
+    "geom:area_square_m":115970716.09147,
     "geom:bbox":"10.3218878656,35.9103021878,10.5123694064,36.026800514",
     "geom:latitude":35.967997,
     "geom:longitude":10.417979,
@@ -78,9 +78,10 @@
     "wof:concordances":{
         "hasc:id":"TN.SS.SB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307356,
-    "wof:geomhash":"76de5682abe32c678e1dd9fa04a73f18",
+    "wof:geomhash":"542a4528086187331883f9ae0af41390",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1108757703,
-    "wof:lastmodified":1566667252,
+    "wof:lastmodified":1695886580,
     "wof:name":"Sidi Bou Ali",
     "wof:parent_id":85679173,
     "wof:placetype":"county",

--- a/data/110/875/770/5/1108757705.geojson
+++ b/data/110/875/770/5/1108757705.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.069009,
-    "geom:area_square_m":693615028.45038,
+    "geom:area_square_m":693615028.450377,
     "geom:bbox":"10.1992679607,35.4097913261,10.6083142947,35.8065767355",
     "geom:latitude":35.623867,
     "geom:longitude":10.384263,
@@ -78,9 +78,10 @@
     "wof:concordances":{
         "hasc:id":"TN.SS.SH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307358,
-    "wof:geomhash":"75feecedabfb61dee9ac67f90fcc6b9e",
+    "wof:geomhash":"612fef0786603e0f138753579ab51fa9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1108757705,
-    "wof:lastmodified":1566667252,
+    "wof:lastmodified":1695886581,
     "wof:name":"Sidi El Hani",
     "wof:parent_id":85679173,
     "wof:placetype":"county",

--- a/data/110/875/770/7/1108757707.geojson
+++ b/data/110/875/770/7/1108757707.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001729,
-    "geom:area_square_m":17343523.306362,
+    "geom:area_square_m":17343294.587665,
     "geom:bbox":"10.618959,35.767432,10.687557,35.821552",
     "geom:latitude":35.794155,
     "geom:longitude":10.653094,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.SS.SS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307359,
-    "wof:geomhash":"bd99dc3a9c6e99c1832255951043d2af",
+    "wof:geomhash":"144c0222a3557a4138debadbac075988",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757707,
-    "wof:lastmodified":1627522834,
+    "wof:lastmodified":1695886549,
     "wof:name":"Sousse Abd Elhamid",
     "wof:parent_id":85679173,
     "wof:placetype":"county",

--- a/data/110/875/771/1/1108757711.geojson
+++ b/data/110/875/771/1/1108757711.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001245,
-    "geom:area_square_m":12481711.509576,
+    "geom:area_square_m":12481813.462307,
     "geom:bbox":"10.5832,35.798571,10.635448,35.848408",
     "geom:latitude":35.823895,
     "geom:longitude":10.609971,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.SS.SJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307360,
-    "wof:geomhash":"9d6bd1a3e4bea2127d617ecc83ed8fc3",
+    "wof:geomhash":"808609829c6a405b81f26e4ed70c599b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757711,
-    "wof:lastmodified":1627522834,
+    "wof:lastmodified":1695886549,
     "wof:name":"Sousse Jouhara",
     "wof:parent_id":85679173,
     "wof:placetype":"county",

--- a/data/110/875/771/3/1108757713.geojson
+++ b/data/110/875/771/3/1108757713.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000583,
-    "geom:area_square_m":5845000.734238,
+    "geom:area_square_m":5845028.004161,
     "geom:bbox":"10.608764,35.816245,10.651667,35.857003",
     "geom:latitude":35.835358,
     "geom:longitude":10.629015,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.SS.SM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307361,
-    "wof:geomhash":"0875e64b94344729bd2f1ec4c12f5d2c",
+    "wof:geomhash":"4af35ad00b4724c626ef0e96a8a18cbb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757713,
-    "wof:lastmodified":1627522834,
+    "wof:lastmodified":1695886549,
     "wof:name":"Sousse Medina",
     "wof:parent_id":85679173,
     "wof:placetype":"county",

--- a/data/110/875/771/5/1108757715.geojson
+++ b/data/110/875/771/5/1108757715.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001319,
-    "geom:area_square_m":13231806.214337,
+    "geom:area_square_m":13231783.201285,
     "geom:bbox":"10.56458,35.771987,10.621686,35.815848",
     "geom:latitude":35.792742,
     "geom:longitude":10.596828,
@@ -54,9 +54,10 @@
     "wof:concordances":{
         "hasc:id":"TN.SS.SR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307363,
-    "wof:geomhash":"1574e86ecc28e2402c1b05be9864e0a0",
+    "wof:geomhash":"751af0539d868ccf941db75745156ad8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -66,7 +67,7 @@
         }
     ],
     "wof:id":1108757715,
-    "wof:lastmodified":1627522834,
+    "wof:lastmodified":1695886549,
     "wof:name":"Sousse Riadh",
     "wof:parent_id":85679173,
     "wof:placetype":"county",

--- a/data/110/875/771/7/1108757717.geojson
+++ b/data/110/875/771/7/1108757717.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002085,
-    "geom:area_square_m":20918958.66911,
+    "geom:area_square_m":20918984.144671,
     "geom:bbox":"10.607265,35.739483,10.662828,35.794605",
     "geom:latitude":35.764636,
     "geom:longitude":10.634799,
@@ -51,9 +51,10 @@
     "wof:concordances":{
         "hasc:id":"TN.SS.SR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307364,
-    "wof:geomhash":"186b9c7c9e9272b9987b6d668c75bfa4",
+    "wof:geomhash":"7f5b2213a1b471d6a5a877a8eead37c3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -63,7 +64,7 @@
         }
     ],
     "wof:id":1108757717,
-    "wof:lastmodified":1627522835,
+    "wof:lastmodified":1695886551,
     "wof:name":"Zaouia-Ksiba-Thr\u00e0at",
     "wof:parent_id":85679173,
     "wof:placetype":"county",

--- a/data/110/875/771/9/1108757719.geojson
+++ b/data/110/875/771/9/1108757719.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.020724,
-    "geom:area_square_m":214541679.749072,
+    "geom:area_square_m":214541679.749062,
     "geom:bbox":"10.3379510579,33.0849877322,10.6009046252,33.2183468289",
     "geom:latitude":33.151687,
     "geom:longitude":10.460414,
@@ -84,9 +84,10 @@
     "wof:concordances":{
         "hasc:id":"TN.TA.BL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307365,
-    "wof:geomhash":"f93cec51ab13d7b3dea5003f16af731e",
+    "wof:geomhash":"76da9e90b22746a12d0f7c215e3ae2a9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":1108757719,
-    "wof:lastmodified":1566667248,
+    "wof:lastmodified":1695886579,
     "wof:name":"Bir Lahmar",
     "wof:parent_id":85679191,
     "wof:placetype":"county",

--- a/data/110/875/772/1/1108757721.geojson
+++ b/data/110/875/772/1/1108757721.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.361524,
-    "geom:area_square_m":3795303718.326748,
+    "geom:area_square_m":3795303418.804853,
     "geom:bbox":"9.721198,31.460119,11.174154,32.483636",
     "geom:latitude":31.895987,
     "geom:longitude":10.409775,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.TA.DH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307367,
-    "wof:geomhash":"4f1f4a031a056378cded17d42406a4cf",
+    "wof:geomhash":"358adb6013efca516b965234a68817c1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757721,
-    "wof:lastmodified":1627522825,
+    "wof:lastmodified":1695886532,
     "wof:name":"Dhiba",
     "wof:parent_id":85679191,
     "wof:placetype":"county",

--- a/data/110/875/772/3/1108757723.geojson
+++ b/data/110/875/772/3/1108757723.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.071166,
-    "geom:area_square_m":737624486.787401,
+    "geom:area_square_m":737624253.517933,
     "geom:bbox":"9.89654,32.939601,10.629112,33.183568",
     "geom:latitude":33.046778,
     "geom:longitude":10.243433,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.TA.GH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307368,
-    "wof:geomhash":"14f4f14d520400bc6f9e95c0291ad774",
+    "wof:geomhash":"6fd4c07aa9508d4057ad863cd692e35a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757723,
-    "wof:lastmodified":1627522828,
+    "wof:lastmodified":1695886537,
     "wof:name":"Ghoumrassen",
     "wof:parent_id":85679191,
     "wof:placetype":"county",

--- a/data/110/875/772/5/1108757725.geojson
+++ b/data/110/875/772/5/1108757725.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.554243,
-    "geom:area_square_m":26866135380.050934,
+    "geom:area_square_m":26866135380.05093,
     "geom:bbox":"8.42449875077,30.228034,10.7364428207,32.7951445267",
     "geom:latitude":31.744022,
     "geom:longitude":9.697015,
@@ -99,9 +99,10 @@
     "wof:concordances":{
         "hasc:id":"TN.TA.RE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307370,
-    "wof:geomhash":"511cc5a84b4a17695645719970a124be",
+    "wof:geomhash":"ac396af7ad1508b159cc2c7d38ed15ef",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1108757725,
-    "wof:lastmodified":1566667269,
+    "wof:lastmodified":1695886583,
     "wof:name":"Remada",
     "wof:parent_id":85679191,
     "wof:placetype":"county",

--- a/data/110/875/772/9/1108757729.geojson
+++ b/data/110/875/772/9/1108757729.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.189406,
-    "geom:area_square_m":1969365261.936278,
+    "geom:area_square_m":1969364710.143215,
     "geom:bbox":"10.715385,32.297061,11.334868,33.098582",
     "geom:latitude":32.76675,
     "geom:longitude":10.968457,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.TA.SA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307371,
-    "wof:geomhash":"0fd085ed5a5d97827da5cc5d716c17ea",
+    "wof:geomhash":"f0d6ba31f5859bbe3acdf6f15e5831ac",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757729,
-    "wof:lastmodified":1627522833,
+    "wof:lastmodified":1695886547,
     "wof:name":"Sam\u00e0r",
     "wof:parent_id":85679191,
     "wof:placetype":"county",

--- a/data/110/875/773/1/1108757731.geojson
+++ b/data/110/875/773/1/1108757731.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.272496,
-    "geom:area_square_m":2836116460.188364,
+    "geom:area_square_m":2836116798.344165,
     "geom:bbox":"10.340422,32.279217,11.175285,33.102362",
     "geom:latitude":32.678164,
     "geom:longitude":10.711529,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.TA.TN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307372,
-    "wof:geomhash":"00cd5313b54cb9259dbe5e29e009369d",
+    "wof:geomhash":"0603476b58f188281253bbd2957d2b98",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757731,
-    "wof:lastmodified":1627522835,
+    "wof:lastmodified":1695886551,
     "wof:name":"Tataouine Nord",
     "wof:parent_id":85679191,
     "wof:placetype":"county",

--- a/data/110/875/773/3/1108757733.geojson
+++ b/data/110/875/773/3/1108757733.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.19186,
-    "geom:area_square_m":1994559918.176817,
+    "geom:area_square_m":1994559730.435335,
     "geom:bbox":"9.898437,32.576322,10.510347,32.992131",
     "geom:latitude":32.78176,
     "geom:longitude":10.191582,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.TA.TS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307373,
-    "wof:geomhash":"87f679f634f8647e948f9bc79dbc1698",
+    "wof:geomhash":"9881e5ec696ff1ad14fa5022069e0d00",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757733,
-    "wof:lastmodified":1627522835,
+    "wof:lastmodified":1695886551,
     "wof:name":"Tataouine Sud",
     "wof:parent_id":85679191,
     "wof:placetype":"county",

--- a/data/110/875/773/5/1108757735.geojson
+++ b/data/110/875/773/5/1108757735.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.128315,
-    "geom:area_square_m":1315145520.877625,
+    "geom:area_square_m":1315145846.18921,
     "geom:bbox":"7.971298,33.764998,8.634959,34.293506",
     "geom:latitude":34.015542,
     "geom:longitude":8.299409,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.TO.DE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307375,
-    "wof:geomhash":"66b07f6846de54f132b75531daf6a4ca",
+    "wof:geomhash":"b53df3ec43356ce74701d1ebe63ca841",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757735,
-    "wof:lastmodified":1627522825,
+    "wof:lastmodified":1695886532,
     "wof:name":"Degu\u00e9che",
     "wof:parent_id":85679095,
     "wof:placetype":"county",

--- a/data/110/875/773/7/1108757737.geojson
+++ b/data/110/875/773/7/1108757737.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.121876,
-    "geom:area_square_m":1252906596.448017,
+    "geom:area_square_m":1252906787.097402,
     "geom:bbox":"7.522311,33.421442,7.927143,34.098525",
     "geom:latitude":33.75942,
     "geom:longitude":7.684152,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.TO.HA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307376,
-    "wof:geomhash":"76c787c7efb58397ba4c678c63363e3e",
+    "wof:geomhash":"84c2f5252f6ac11b2775f8e30515da56",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757737,
-    "wof:lastmodified":1627522829,
+    "wof:lastmodified":1695886539,
     "wof:name":"Hazoua",
     "wof:parent_id":85679095,
     "wof:placetype":"county",

--- a/data/110/875/773/9/1108757739.geojson
+++ b/data/110/875/773/9/1108757739.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.154802,
-    "geom:area_square_m":1590404713.105905,
+    "geom:area_square_m":1590404713.105888,
     "geom:bbox":"7.7149080809,33.5085293714,8.12952740501,34.1231288222",
     "geom:latitude":33.812027,
     "geom:longitude":7.892555,
@@ -123,9 +123,10 @@
     "wof:concordances":{
         "hasc:id":"TN.TO.NA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307377,
-    "wof:geomhash":"0bbce8cfa60b8c689ef1ddbecf5e9861",
+    "wof:geomhash":"ba249a862f6f5c5cc034b66f29d8bd54",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1108757739,
-    "wof:lastmodified":1566667271,
+    "wof:lastmodified":1695886584,
     "wof:name":"Nafta",
     "wof:parent_id":85679095,
     "wof:placetype":"county",

--- a/data/110/875/774/1/1108757741.geojson
+++ b/data/110/875/774/1/1108757741.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.092093,
-    "geom:area_square_m":941192174.467787,
+    "geom:area_square_m":941191877.307521,
     "geom:bbox":"7.544525,34.057299,8.11221,34.516047",
     "geom:latitude":34.256859,
     "geom:longitude":7.890732,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.TO.TA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307378,
-    "wof:geomhash":"76668fec6dbbc17a9ac4a9cad088c857",
+    "wof:geomhash":"f7900853ef51775794f0b1a6528a30f3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757741,
-    "wof:lastmodified":1627522834,
+    "wof:lastmodified":1695886549,
     "wof:name":"Tamaghza",
     "wof:parent_id":85679095,
     "wof:placetype":"county",

--- a/data/110/875/774/3/1108757743.geojson
+++ b/data/110/875/774/3/1108757743.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.081327,
-    "geom:area_square_m":834804772.002449,
+    "geom:area_square_m":834804648.693062,
     "geom:bbox":"7.964578,33.649188,8.301795,34.16272",
     "geom:latitude":33.887378,
     "geom:longitude":8.106046,
@@ -168,9 +168,10 @@
     "wof:concordances":{
         "hasc:id":"TN.TO.TO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307380,
-    "wof:geomhash":"c10b779a11d9403fa425bea07940db58",
+    "wof:geomhash":"0c7c2129aaaab3f77afb08a0195cf740",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -180,7 +181,7 @@
         }
     ],
     "wof:id":1108757743,
-    "wof:lastmodified":1636495672,
+    "wof:lastmodified":1695886660,
     "wof:name":"Tozeur",
     "wof:parent_id":85679095,
     "wof:placetype":"county",

--- a/data/110/875/774/7/1108757747.geojson
+++ b/data/110/875/774/7/1108757747.geojson
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"TN.TU.BS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307381,
-    "wof:geomhash":"793b699d370cd618bc2d5c6dd08ba106",
+    "wof:geomhash":"e1a2a65293d569a2faae388be55df5e1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108757747,
-    "wof:lastmodified":1566667272,
+    "wof:lastmodified":1695886584,
     "wof:name":"Bab Souika",
     "wof:parent_id":85679123,
     "wof:placetype":"county",

--- a/data/110/875/774/9/1108757749.geojson
+++ b/data/110/875/774/9/1108757749.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00034,
-    "geom:area_square_m":3366237.653893,
+    "geom:area_square_m":3366211.313921,
     "geom:bbox":"10.168601,36.755205,10.191734,36.777525",
     "geom:latitude":36.765073,
     "geom:longitude":10.180706,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.TU.OU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307382,
-    "wof:geomhash":"118d1a10c7ab876cd6bd06fb572342b5",
+    "wof:geomhash":"a71e4922c84e0994085ce6659b6ed51d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757749,
-    "wof:lastmodified":1627522827,
+    "wof:lastmodified":1695886535,
     "wof:name":"El Ouardia",
     "wof:parent_id":85679123,
     "wof:placetype":"county",

--- a/data/110/875/775/1/1108757751.geojson
+++ b/data/110/875/775/1/1108757751.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000153,
-    "geom:area_square_m":1518872.649923,
+    "geom:area_square_m":1518892.710501,
     "geom:bbox":"10.116248,36.814107,10.133513,36.827497",
     "geom:latitude":36.820389,
     "geom:longitude":10.124958,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.TU.TA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307383,
-    "wof:geomhash":"28bb2b18a4927a73438d4bc4483368ef",
+    "wof:geomhash":"2fd1dca7dded460b6bc45befd7116103",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757751,
-    "wof:lastmodified":1627522827,
+    "wof:lastmodified":1695886535,
     "wof:name":"Ettahrir",
     "wof:parent_id":85679123,
     "wof:placetype":"county",

--- a/data/110/875/775/3/1108757753.geojson
+++ b/data/110/875/775/3/1108757753.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000097,
-    "geom:area_square_m":959856.903108,
+    "geom:area_square_m":959856.047975,
     "geom:bbox":"10.127112,36.783013,10.143069,36.793213",
     "geom:latitude":36.788576,
     "geom:longitude":10.136327,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.TU.EZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307384,
-    "wof:geomhash":"b61bd5ee5919f40737cdeea7a9a5cc48",
+    "wof:geomhash":"65f00c46dcfd59776ab14f5cd75d91d2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757753,
-    "wof:lastmodified":1627522827,
+    "wof:lastmodified":1695886535,
     "wof:name":"Ezouhour",
     "wof:parent_id":85679123,
     "wof:placetype":"county",

--- a/data/110/875/775/5/1108757755.geojson
+++ b/data/110/875/775/5/1108757755.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.02903,
-    "geom:area_square_m":287426190.112658,
+    "geom:area_square_m":287426190.112656,
     "geom:bbox":"10.005783,36.689451,10.35625,36.941993",
     "geom:latitude":36.800932,
     "geom:longitude":10.179767,
@@ -451,7 +451,7 @@
     ],
     "wof:country":"TN",
     "wof:created":1481307385,
-    "wof:geomhash":"45c05fde79b3d90dd0bb7f331ee1adb2",
+    "wof:geomhash":"309572345faac8bf52eafb7ed77428af",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -461,7 +461,7 @@
         }
     ],
     "wof:id":1108757755,
-    "wof:lastmodified":1636495672,
+    "wof:lastmodified":1695886660,
     "wof:name":"Tunis",
     "wof:parent_id":85679123,
     "wof:placetype":"county",

--- a/data/110/875/775/7/1108757757.geojson
+++ b/data/110/875/775/7/1108757757.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.055707,
-    "geom:area_square_m":553597103.147235,
+    "geom:area_square_m":553597203.427469,
     "geom:bbox":"9.749148,36.393232,10.188102,36.652715",
     "geom:latitude":36.516394,
     "geom:longitude":9.985856,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.ZA.BM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307386,
-    "wof:geomhash":"067df9ec734299bc10b0639cdaead699",
+    "wof:geomhash":"e740fc9c5421a0c7e3fbdc044d60d8cd",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757757,
-    "wof:lastmodified":1627522825,
+    "wof:lastmodified":1695886532,
     "wof:name":"Bir Mecharga",
     "wof:parent_id":85679179,
     "wof:placetype":"county",

--- a/data/110/875/775/9/1108757759.geojson
+++ b/data/110/875/775/9/1108757759.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.098225,
-    "geom:area_square_m":979053529.640322,
+    "geom:area_square_m":979053529.640315,
     "geom:bbox":"9.60128953603,36.0544309101,10.1039808571,36.4682179061",
     "geom:latitude":36.284394,
     "geom:longitude":9.853111,
@@ -84,9 +84,10 @@
     "wof:concordances":{
         "hasc:id":"TN.ZA.FA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307387,
-    "wof:geomhash":"685bbe532b162d72a654f362cf443cd2",
+    "wof:geomhash":"b32c8026b6672ca94a527c0da39e2e95",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":1108757759,
-    "wof:lastmodified":1566667267,
+    "wof:lastmodified":1695886583,
     "wof:name":"El Fahs",
     "wof:parent_id":85679179,
     "wof:placetype":"county",

--- a/data/110/875/776/1/1108757761.geojson
+++ b/data/110/875/776/1/1108757761.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.034606,
-    "geom:area_square_m":345702860.634232,
+    "geom:area_square_m":345702860.634216,
     "geom:bbox":"9.86585113161,36.0035374191,10.1514150491,36.2101647465",
     "geom:latitude":36.109598,
     "geom:longitude":9.993532,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"TN.ZA.NA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307389,
-    "wof:geomhash":"f1f6f0b871c92798f84414a3cf8d07d9",
+    "wof:geomhash":"e9792381250255cb62c067c4d7c44c01",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1108757761,
-    "wof:lastmodified":1566667250,
+    "wof:lastmodified":1695886580,
     "wof:name":"Nadhour",
     "wof:parent_id":85679179,
     "wof:placetype":"county",

--- a/data/110/875/776/5/1108757765.geojson
+++ b/data/110/875/776/5/1108757765.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.025748,
-    "geom:area_square_m":256919062.421492,
+    "geom:area_square_m":256919183.873167,
     "geom:bbox":"10.00948,36.130761,10.262591,36.28401",
     "geom:latitude":36.199368,
     "geom:longitude":10.146358,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TN.ZA.SA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307390,
-    "wof:geomhash":"4a60bb5b2b578c3fca3312ca10d1dfd8",
+    "wof:geomhash":"022d5c2b3438f097b42d981012c744b5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108757765,
-    "wof:lastmodified":1627522833,
+    "wof:lastmodified":1695886547,
     "wof:name":"Saouaf",
     "wof:parent_id":85679179,
     "wof:placetype":"county",

--- a/data/110/875/776/7/1108757767.geojson
+++ b/data/110/875/776/7/1108757767.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.04001,
-    "geom:area_square_m":398153582.237569,
+    "geom:area_square_m":398153615.611783,
     "geom:bbox":"10.004795,36.301268,10.378141,36.51328",
     "geom:latitude":36.40945,
     "geom:longitude":10.188541,
@@ -150,9 +150,10 @@
     "wof:concordances":{
         "hasc:id":"TN.ZA.ZA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307391,
-    "wof:geomhash":"97deba57a01250cc0cf4d637a41e34fc",
+    "wof:geomhash":"7f95846bb135e607d3dd2c210480a1a5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -162,7 +163,7 @@
         }
     ],
     "wof:id":1108757767,
-    "wof:lastmodified":1636495671,
+    "wof:lastmodified":1695886660,
     "wof:name":"Zaghouan",
     "wof:parent_id":85679179,
     "wof:placetype":"county",

--- a/data/110/875/776/9/1108757769.geojson
+++ b/data/110/875/776/9/1108757769.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.034302,
-    "geom:area_square_m":341826588.64642,
+    "geom:area_square_m":341826588.646421,
     "geom:bbox":"10.0573142441,36.2135182609,10.3797007471,36.3895910819",
     "geom:latitude":36.30193,
     "geom:longitude":10.238288,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"TN.ZA.ZR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TN",
     "wof:created":1481307392,
-    "wof:geomhash":"6668aa3c02098adbd93f5ef2ca76f2ee",
+    "wof:geomhash":"09615f96071302ee8240aab828d870a5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1108757769,
-    "wof:lastmodified":1566667249,
+    "wof:lastmodified":1695886580,
     "wof:name":"Zriba",
     "wof:parent_id":85679179,
     "wof:placetype":"county",

--- a/data/110/880/715/9/1108807159.geojson
+++ b/data/110/880/715/9/1108807159.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.04694,
-    "geom:area_square_m":463861661.63499,
+    "geom:area_square_m":463861708.178713,
     "geom:bbox":"9.973696,36.817226,10.284072,37.116491",
     "geom:latitude":36.948627,
     "geom:longitude":10.133096,
@@ -189,12 +189,14 @@
     "wof:concordances":{
         "fips:code":"TS38",
         "hasc:id":"TN.AN",
+        "iso:code":"TN-12",
         "iso:id":"TN-12",
         "wd:id":"Q233116"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TN",
     "wof:created":1486078286,
-    "wof:geomhash":"80617187a9d03f64f626f12f217bb598",
+    "wof:geomhash":"5cee75337898139d39730708a4f0e52a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -211,7 +213,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690874839,
+    "wof:lastmodified":1695884537,
     "wof:name":"Ariana",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/327/03/85632703.geojson
+++ b/data/856/327/03/85632703.geojson
@@ -1196,6 +1196,7 @@
         "hasc:id":"TN",
         "icao:code":"TS",
         "ioc:id":"TUN",
+        "iso:code":"TN",
         "itu:id":"TUN",
         "loc:id":"n79065220",
         "m49:code":"788",
@@ -1210,6 +1211,7 @@
         "wk:page":"Tunisia",
         "wmo:id":"TS"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TN",
     "wof:country_alpha3":"TUN",
     "wof:geom_alt":[
@@ -1234,7 +1236,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1694639511,
+    "wof:lastmodified":1695881166,
     "wof:name":"Tunisia",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/790/95/85679095.geojson
+++ b/data/856/790/95/85679095.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.578414,
-    "geom:area_square_m":5934453776.901796,
+    "geom:area_square_m":5934453663.478989,
     "geom:bbox":"7.522311,33.421442,8.634959,34.516047",
     "geom:latitude":33.927509,
     "geom:longitude":7.968627,
@@ -287,17 +287,19 @@
         "gn:id":2464645,
         "gp:id":2347255,
         "hasc:id":"TN.TO",
+        "iso:code":"TN-72",
         "iso:id":"TN-72",
         "qs_pg:id":894993,
         "unlc:id":"TN-72",
         "wd:id":"Q388059",
         "wk:page":"Tozeur Governorate"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f7e11ff70be6a369bbc7d046ff070de7",
+    "wof:geomhash":"187f235911edfaf3dacd8cab8afe82aa",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -314,7 +316,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690874830,
+    "wof:lastmodified":1695884806,
     "wof:name":"Tozeur",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/790/99/85679099.geojson
+++ b/data/856/790/99/85679099.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.112846,
-    "geom:area_square_m":1117619702.455654,
+    "geom:area_square_m":1117619219.681476,
     "geom:bbox":"9.564629,36.582765,10.117186,36.967516",
     "geom:latitude":36.778764,
     "geom:longitude":9.865321,
@@ -327,15 +327,17 @@
         "gn:id":6201192,
         "gp:id":2347247,
         "hasc:id":"TN.MN",
+        "iso:code":"TN-14",
         "iso:id":"TN-14",
         "qs_pg:id":900784,
         "wd:id":"Q734328"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7a6b3722b836314f54430888c091564e",
+    "wof:geomhash":"a92659e5574a21bd38171730473cd952",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -352,7 +354,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690874831,
+    "wof:lastmodified":1695884806,
     "wof:name":"Manubah",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/791/03/85679103.geojson
+++ b/data/856/791/03/85679103.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.367467,
-    "geom:area_square_m":3643846294.716637,
+    "geom:area_square_m":3643846829.966288,
     "geom:bbox":"8.890295,36.333111,9.864532,37.158749",
     "geom:latitude":36.684119,
     "geom:longitude":9.317676,
@@ -267,17 +267,19 @@
         "gn:id":2472770,
         "gp:id":2347242,
         "hasc:id":"TN.BJ",
+        "iso:code":"TN-31",
         "iso:id":"TN-31",
         "qs_pg:id":891337,
         "unlc:id":"TN-31",
         "wd:id":"Q276576",
         "wk:page":"B\u00e9ja Governorate"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8399facd676f898a26c6ea375c3db38a",
+    "wof:geomhash":"55c4160c60a259aa447b7c5837485425",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -294,7 +296,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690874831,
+    "wof:lastmodified":1695884537,
     "wof:name":"B\u00e9ja",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/791/07/85679107.geojson
+++ b/data/856/791/07/85679107.geojson
@@ -298,12 +298,14 @@
         "gn:id":2472477,
         "gp:id":2347248,
         "hasc:id":"TN.BA",
+        "iso:code":"TN-13",
         "iso:id":"TN-13",
         "qs_pg:id":1097077,
         "unlc:id":"TN-13",
         "wd:id":"Q238555",
         "wk:page":"Ben Arous Governorate"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TN",
     "wof:geom_alt":[
         "quattroshapes"
@@ -325,7 +327,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1694639832,
+    "wof:lastmodified":1695884537,
     "wof:name":"Ben Arous",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/791/13/85679113.geojson
+++ b/data/856/791/13/85679113.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.372769,
-    "geom:area_square_m":3677384413.069078,
+    "geom:area_square_m":3677384184.954041,
     "geom:bbox":"8.90125,36.722968,10.283778,37.542946",
     "geom:latitude":37.078455,
     "geom:longitude":9.617838,
@@ -293,17 +293,19 @@
         "gn:id":2472699,
         "gp:id":2347243,
         "hasc:id":"TN.BZ",
+        "iso:code":"TN-23",
         "iso:id":"TN-23",
         "qs_pg:id":219621,
         "unlc:id":"TN-23",
         "wd:id":"Q241129",
         "wk:page":"Bizerte Governorate"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"386e982c9d272bd926c73b79baac5ce3",
+    "wof:geomhash":"421f9132094f2cc7fa58c990ee902718",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -320,7 +322,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690874837,
+    "wof:lastmodified":1695884537,
     "wof:name":"Bizerte",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/791/15/85679115.geojson
+++ b/data/856/791/15/85679115.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.313891,
-    "geom:area_square_m":3114682621.026484,
+    "geom:area_square_m":3114682736.568245,
     "geom:bbox":"8.153737,36.342899,9.074043,37.012381",
     "geom:latitude":36.63208,
     "geom:longitude":8.701694,
@@ -290,17 +290,19 @@
         "gn:id":2470085,
         "gp:id":2347237,
         "hasc:id":"TN.JE",
+        "iso:code":"TN-32",
         "iso:id":"TN-32",
         "qs_pg:id":235642,
         "unlc:id":"TN-32",
         "wd:id":"Q276580",
         "wk:page":"Jendouba Governorate"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a6d70681518bf8dd3d1675cc2ff96996",
+    "wof:geomhash":"754f9b4d728933095173c68d9f78b76e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -317,7 +319,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690874836,
+    "wof:lastmodified":1695884807,
     "wof:name":"Jendouba",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/791/19/85679119.geojson
+++ b/data/856/791/19/85679119.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.287404,
-    "geom:area_square_m":2849614261.546748,
+    "geom:area_square_m":2849614516.16358,
     "geom:bbox":"10.344663,36.352813,11.137889,37.143749",
     "geom:latitude":36.6928,
     "geom:longitude":10.718352,
@@ -293,17 +293,19 @@
         "gn:id":2468576,
         "gp:id":2347244,
         "hasc:id":"TN.NB",
+        "iso:code":"TN-21",
         "iso:id":"TN-21",
         "qs_pg:id":219622,
         "unlc:id":"TN-21",
         "wd:id":"Q328145",
         "wk:page":"Nabeul Governorate"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"05860fd8b181ff0f5ee6b7f8b82f52ce",
+    "wof:geomhash":"c4a7b3c543194ec27e375e89a43b3389",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -320,7 +322,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690874833,
+    "wof:lastmodified":1695884807,
     "wof:name":"Nabeul",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/791/23/85679123.geojson
+++ b/data/856/791/23/85679123.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.029752,
-    "geom:area_square_m":294580324.298937,
+    "geom:area_square_m":294580324.298939,
     "geom:bbox":"10.005783,36.689451,10.35625,36.941993",
     "geom:latitude":36.800587,
     "geom:longitude":10.179269,
@@ -269,11 +269,13 @@
         "gn:id":2464464,
         "gp:id":2347256,
         "hasc:id":"TN.TU",
+        "iso:code":"TN-11",
         "iso:id":"TN-11",
         "qs_pg:id":1083877,
         "wd:id":"Q328109",
         "wk:page":"Tunis Governorate"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         1108757755,
         421195703
@@ -282,7 +284,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b6a369cfb5474df369ad005f84548caa",
+    "wof:geomhash":"966d012288e43c10a42b7177154a651e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -299,7 +301,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690874836,
+    "wof:lastmodified":1695884807,
     "wof:name":"Tunis",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/791/31/85679131.geojson
+++ b/data/856/791/31/85679131.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.51105,
-    "geom:area_square_m":5110311831.52072,
+    "geom:area_square_m":5110311517.276903,
     "geom:bbox":"8.253129,35.614258,9.16197,36.444283",
     "geom:latitude":36.031308,
     "geom:longitude":8.679645,
@@ -303,16 +303,18 @@
         "gn:id":2473637,
         "gp:id":2347239,
         "hasc:id":"TN.KF",
+        "iso:code":"TN-33",
         "iso:id":"TN-33",
         "qs_pg:id":239520,
         "unlc:id":"TN-33",
         "wd:id":"Q328199"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6c247537f4cbb73cf6cde89922297b94",
+    "wof:geomhash":"35262b536834a8053890066f7168f9f5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -329,7 +331,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690874834,
+    "wof:lastmodified":1695884807,
     "wof:name":"Le Kef",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/791/33/85679133.geojson
+++ b/data/856/791/33/85679133.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.812223,
-    "geom:area_square_m":8204934262.088953,
+    "geom:area_square_m":8204933900.668098,
     "geom:bbox":"8.245813,34.631195,9.330506,35.782007",
     "geom:latitude":35.217829,
     "geom:longitude":8.755349,
@@ -286,16 +286,18 @@
         "gn:id":2473460,
         "gp:id":2347235,
         "hasc:id":"TN.KS",
+        "iso:code":"TN-42",
         "iso:id":"TN-42",
         "qs_pg:id":319012,
         "wd:id":"Q388047",
         "wk:page":"Kasserine Governorate"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4b70a6e09bb7bcca394842775bc2121a",
+    "wof:geomhash":"c758ad739eb9de3501c28930676164c3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -312,7 +314,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690874832,
+    "wof:lastmodified":1695884537,
     "wof:name":"Kass\u00e9rine",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/791/37/85679137.geojson
+++ b/data/856/791/37/85679137.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.725886,
-    "geom:area_square_m":7460793313.395738,
+    "geom:area_square_m":7460793375.404113,
     "geom:bbox":"9.242761,33.265367,10.474403,34.271099",
     "geom:latitude":33.774966,
     "geom:longitude":9.796599,
@@ -299,17 +299,19 @@
         "gn:id":2468365,
         "gp:id":2347250,
         "hasc:id":"TN.GB",
+        "iso:code":"TN-81",
         "iso:id":"TN-81",
         "qs_pg:id":1083876,
         "unlc:id":"TN-81",
         "wd:id":"Q242263",
         "wk:page":"Gab\u00e8s Governorate"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"73507c556c1efd8244d30cfe8339f7f3",
+    "wof:geomhash":"8dec43cc2addb192380a609026aa554a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -326,7 +328,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690874835,
+    "wof:lastmodified":1695884537,
     "wof:name":"Gab\u00e8s",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/791/41/85679141.geojson
+++ b/data/856/791/41/85679141.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.742995,
-    "geom:area_square_m":7580483817.083055,
+    "geom:area_square_m":7580483476.816202,
     "geom:bbox":"8.036337,34.070451,9.574618,34.805777",
     "geom:latitude":34.400339,
     "geom:longitude":8.761395,
@@ -300,16 +300,18 @@
         "gn:id":2468351,
         "gp:id":2347238,
         "hasc:id":"TN.GF",
+        "iso:code":"TN-71",
         "iso:id":"TN-71",
         "qs_pg:id":239519,
         "unlc:id":"TN-71",
         "wd:id":"Q269968"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"cfdd992d4cbddb8454bedd983a118036",
+    "wof:geomhash":"bf407bbb09b3773dc173cd13cc12ccc9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -326,7 +328,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690874835,
+    "wof:lastmodified":1695884808,
     "wof:name":"Gafsa",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/791/47/85679147.geojson
+++ b/data/856/791/47/85679147.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.729889,
-    "geom:area_square_m":7405584780.622799,
+    "geom:area_square_m":7405585350.329155,
     "geom:bbox":"8.921322,34.266153,10.064824,35.482304",
     "geom:latitude":34.859826,
     "geom:longitude":9.547942,
@@ -296,16 +296,18 @@
         "gn:id":2465837,
         "gp:id":2347253,
         "hasc:id":"TN.SZ",
+        "iso:code":"TN-43",
         "iso:id":"TN-43",
         "qs_pg:id":894991,
         "wd:id":"Q327097",
         "wk:page":"Sidi Bouzid Governorate"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ab697db54a7fbf23b7f360fb2840211b",
+    "wof:geomhash":"3b897435c1c31a0474c562a0efd16df9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -322,7 +324,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690874837,
+    "wof:lastmodified":1695884808,
     "wof:name":"Sidi Bou Zid",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/791/51/85679151.geojson
+++ b/data/856/791/51/85679151.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.690372,
-    "geom:area_square_m":7012954940.780891,
+    "geom:area_square_m":7012954162.272614,
     "geom:bbox":"9.699184,34.165514,11.322861,35.266486",
     "geom:latitude":34.762205,
     "geom:longitude":10.3782,
@@ -296,17 +296,19 @@
         "gn:id":2467450,
         "gp:id":2347252,
         "hasc:id":"TN.SF",
+        "iso:code":"TN-61",
         "iso:id":"TN-61",
         "qs_pg:id":235643,
         "unlc:id":"TN-61",
         "wd:id":"Q241145",
         "wk:page":"Sfax Governorate"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e94eecbfdbf8383621127fa13e4f5091",
+    "wof:geomhash":"bf7fa90f6bda0a80878cb4ef82b71761",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -323,7 +325,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690874832,
+    "wof:lastmodified":1695884807,
     "wof:name":"Sfax",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/791/57/85679157.geojson
+++ b/data/856/791/57/85679157.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.465263,
-    "geom:area_square_m":4651202015.291284,
+    "geom:area_square_m":4651201449.465808,
     "geom:bbox":"8.928141,35.472813,9.763896,36.458594",
     "geom:latitude":36.052207,
     "geom:longitude":9.33778,
@@ -284,17 +284,19 @@
         "gn:id":2465027,
         "gp:id":2347245,
         "hasc:id":"TN.SL",
+        "iso:code":"TN-34",
         "iso:id":"TN-34",
         "qs_pg:id":319038,
         "unlc:id":"TN-34",
         "wd:id":"Q328115",
         "wk:page":"Siliana Governorate"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c025efd2ca11d00940fa90a37576d927",
+    "wof:geomhash":"ab0c67bf7d17225c40a740b0ede8a423",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -311,7 +313,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690874831,
+    "wof:lastmodified":1695884807,
     "wof:name":"Siliana",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/791/61/85679161.geojson
+++ b/data/856/791/61/85679161.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.288739,
-    "geom:area_square_m":2913186934.848865,
+    "geom:area_square_m":2913186601.762732,
     "geom:bbox":"10.163154,35.085371,11.162861,35.581521",
     "geom:latitude":35.31866,
     "geom:longitude":10.629786,
@@ -290,17 +290,19 @@
         "gn:id":2473574,
         "gp:id":2347240,
         "hasc:id":"TN.MH",
+        "iso:code":"TN-53",
         "iso:id":"TN-53",
         "qs_pg:id":914011,
         "unlc:id":"TN-53",
         "wd:id":"Q328164",
         "wk:page":"Mahdia Governorate"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"906ca768bdd9ffd1c99f2e99c0e5f605",
+    "wof:geomhash":"2154df3fd2890b007a8b90458b5e46ea",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -317,7 +319,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690874831,
+    "wof:lastmodified":1695884807,
     "wof:name":"Mahdia",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/791/65/85679165.geojson
+++ b/data/856/791/65/85679165.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.104479,
-    "geom:area_square_m":1050464895.369083,
+    "geom:area_square_m":1050464834.712461,
     "geom:bbox":"10.494583,35.42904,11.050389,35.805416",
     "geom:latitude":35.598783,
     "geom:longitude":10.770898,
@@ -299,17 +299,19 @@
         "gn:id":2473495,
         "gp:id":2347241,
         "hasc:id":"TN.MS",
+        "iso:code":"TN-52",
         "iso:id":"TN-52",
         "qs_pg:id":424067,
         "unlc:id":"TN-52",
         "wd:id":"Q318102",
         "wk:page":"Monastir Governorate"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2ecf80c4f5ac43f377c5c983cfaf506c",
+    "wof:geomhash":"dc764d5ad644ad78c859f93e82a7d5cc",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -326,7 +328,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690874834,
+    "wof:lastmodified":1695884808,
     "wof:name":"Monastir",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/791/71/85679171.geojson
+++ b/data/856/791/71/85679171.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.651695,
-    "geom:area_square_m":6551481241.059287,
+    "geom:area_square_m":6551481419.030581,
     "geom:bbox":"9.267726,35.00682,10.304758,36.136795",
     "geom:latitude":35.608502,
     "geom:longitude":9.861295,
@@ -266,17 +266,19 @@
         "gn:id":2473451,
         "gp:id":2347236,
         "hasc:id":"TN.KR",
+        "iso:code":"TN-41",
         "iso:id":"TN-41",
         "qs_pg:id":424066,
         "unlc:id":"TN-41",
         "wd:id":"Q276574",
         "wk:page":"Kairouan Governorate"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"bc08c803131f52c087d83026cf45adf3",
+    "wof:geomhash":"b43512d7bb74a5c068377079ac772f8a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -293,7 +295,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690874837,
+    "wof:lastmodified":1695884808,
     "wof:name":"Kairouan",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/791/73/85679173.geojson
+++ b/data/856/791/73/85679173.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.266278,
-    "geom:area_square_m":2668319048.923204,
+    "geom:area_square_m":2668318675.806515,
     "geom:bbox":"10.1562,35.409791,10.687557,36.378586",
     "geom:latitude":35.864081,
     "geom:longitude":10.410744,
@@ -290,17 +290,19 @@
         "gn:id":2464912,
         "gp:id":2347246,
         "hasc:id":"TN.SS",
+        "iso:code":"TN-51",
         "iso:id":"TN-51",
         "qs_pg:id":219623,
         "unlc:id":"TN-51",
         "wd:id":"Q276565",
         "wk:page":"Sousse Governorate"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"01bb7cfa86b17a7798085cf5f3806d42",
+    "wof:geomhash":"fd8e0e01bbfe496c705cf756cf953726",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -317,7 +319,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690874832,
+    "wof:lastmodified":1695884807,
     "wof:name":"Sousse",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/791/79/85679179.geojson
+++ b/data/856/791/79/85679179.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.288597,
-    "geom:area_square_m":2875252726.727168,
+    "geom:area_square_m":2875252998.377123,
     "geom:bbox":"9.60129,36.003537,10.379701,36.652715",
     "geom:latitude":36.320052,
     "geom:longitude":10.014018,
@@ -284,17 +284,19 @@
         "gn:id":2464038,
         "gp:id":2347257,
         "hasc:id":"TN.ZA",
+        "iso:code":"TN-22",
         "iso:id":"TN-22",
         "qs_pg:id":1285509,
         "unlc:id":"TN-22",
         "wd:id":"Q27916",
         "wk:page":"Zaghouan Governorate"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"332f13c6682931064e9ebb69ee560201",
+    "wof:geomhash":"f89c08767487fc97968f58de0e78a35e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -311,7 +313,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690874835,
+    "wof:lastmodified":1695884808,
     "wof:name":"Zaghouan",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/791/83/85679183.geojson
+++ b/data/856/791/83/85679183.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.904467,
-    "geom:area_square_m":9364291801.466751,
+    "geom:area_square_m":9364292893.210442,
     "geom:bbox":"9.717007,32.26966,11.599217,33.902943",
     "geom:latitude":33.142216,
     "geom:longitude":10.884883,
@@ -289,16 +289,18 @@
         "gn:id":2469470,
         "gp:id":2347249,
         "hasc:id":"TN.ME",
+        "iso:code":"TN-82",
         "iso:id":"TN-82",
         "qs_pg:id":424086,
         "wd:id":"Q327087",
         "wk:page":"Medenine Governorate"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fe4d4fbd7093eac30d8a4e25576d20a6",
+    "wof:geomhash":"ac2c668c851c9e46db847ad92976fe4a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -315,7 +317,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690874836,
+    "wof:lastmodified":1695884537,
     "wof:name":"M\u00e9denine",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/791/87/85679187.geojson
+++ b/data/856/791/87/85679187.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.171927,
-    "geom:area_square_m":22451914712.956619,
+    "geom:area_square_m":22451914853.472263,
     "geom:bbox":"7.744395,32.462897,9.97294,34.189483",
     "geom:latitude":33.278301,
     "geom:longitude":8.882083,
@@ -297,17 +297,19 @@
         "gn:id":2468014,
         "gp:id":2347251,
         "hasc:id":"TN.KB",
+        "iso:code":"TN-73",
         "iso:id":"TN-73",
         "qs_pg:id":319051,
         "unlc:id":"TN-73",
         "wd:id":"Q286063",
         "wk:page":"Kebili Governorate"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d67dec7b2e8c4961c83f4c3311edf7f4",
+    "wof:geomhash":"7d3b4a154639cc3c8d92ab1448430b23",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -324,7 +326,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690874833,
+    "wof:lastmodified":1695884807,
     "wof:name":"Kebili",
     "wof:parent_id":85632703,
     "wof:placetype":"region",

--- a/data/856/791/91/85679191.geojson
+++ b/data/856/791/91/85679191.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.661419,
-    "geom:area_square_m":38413646905.215569,
+    "geom:area_square_m":38413644963.947441,
     "geom:bbox":"8.424499,30.228034,11.334868,33.218347",
     "geom:latitude":31.969122,
     "geom:longitude":9.949525,
@@ -290,17 +290,19 @@
         "gn:id":2464698,
         "gp:id":2347254,
         "hasc:id":"TN.TA",
+        "iso:code":"TN-83",
         "iso:id":"TN-83",
         "qs_pg:id":894992,
         "unlc:id":"TN-83",
         "wd:id":"Q327045",
         "wk:page":"Tataouine Governorate"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"62eb81d5f1187e3e29fdb306250d00f6",
+    "wof:geomhash":"ae0ce739c4b574633ce5d3ebcf700694",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -317,7 +319,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690874834,
+    "wof:lastmodified":1695884807,
     "wof:name":"Tataouine",
     "wof:parent_id":85632703,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.